### PR TITLE
feat(lint): reframe diagnostic output

### DIFF
--- a/hooks/lint.ts
+++ b/hooks/lint.ts
@@ -37,7 +37,8 @@ function run(filePath: string): void {
 		writeLintAttempts(attempts);
 
 		if (count >= settings.maxLintAttempts && result.hookSpecificOutput) {
-			result.hookSpecificOutput.additionalContext = `CRITICAL: ${filePath} failed linting ${count} times. If you're stuck in a loop, STOP editing this file and report lint errors to user for assistance.\n${result.hookSpecificOutput.additionalContext}`;
+			const loopNotice = `<workspace_diagnostics source="lint-loop">\n${filePath} has surfaced lint issues ${count} times. The fix loop appears stuck — surface the remaining diagnostics to the user instead of editing further?\n</workspace_diagnostics>`;
+			result.hookSpecificOutput.additionalContext = `${loopNotice}\n${result.hookSpecificOutput.additionalContext}`;
 		}
 
 		writeStdoutJson(result);

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -254,6 +254,11 @@ export interface StopDecisionResult {
 	resetStopAttempts?: true;
 }
 
+export interface FormattedErrors {
+	lines: Array<string>;
+	totalIssues: number;
+}
+
 interface StopDecisionInput {
 	errorFiles: Array<string>;
 	lintAttempts: Record<string, number>;
@@ -431,15 +436,16 @@ export function stopDecision(input: StopDecisionInput): StopDecisionResult | und
 		return undefined;
 	}
 
+	const fileList = input.errorFiles.join(", ");
 	if (input.stopAttempts >= DEFAULT_MAX_STOP_ATTEMPTS) {
 		return {
-			reason: `Unresolved lint errors in: ${input.errorFiles.join(", ")}. These may be pre-existing.`,
+			reason: `<workspace_diagnostics source="eslint">\nUnresolved lint issues remain in: ${fileList}. They may be pre-existing.\n</workspace_diagnostics>`,
 		};
 	}
 
 	return {
 		decision: "block",
-		reason: `Lint errors detected in: ${input.errorFiles.join(", ")}. If related to your changes, please fix before finishing.`,
+		reason: `<workspace_diagnostics source="eslint">\nLint issues remain in: ${fileList}. If related to recent changes, address before continuing?\n</workspace_diagnostics>`,
 	};
 }
 
@@ -643,31 +649,70 @@ setTimeout(() => {
 	}
 }
 
-export function formatErrors(output: string): Array<string> {
-	return output
-		.split("\n")
-		.filter((line) => /error/i.test(line))
-		.slice(0, MAX_ERRORS);
+const RULE_TOKEN_PATTERN = /([\w-]+\/[\w-]+|[\w-]+)$/;
+
+export function formatErrors(output: string, max = MAX_ERRORS): FormattedErrors {
+	const errorLines = output.split("\n").filter((line) => /error/i.test(line));
+
+	const counts = new Map<string, { count: number; sample: string }>();
+	const ungrouped: Array<string> = [];
+	for (const line of errorLines) {
+		const rule = extractRule(line);
+		if (rule === undefined) {
+			ungrouped.push(line);
+			continue;
+		}
+
+		const existing = counts.get(rule);
+		if (existing === undefined) {
+			counts.set(rule, { count: 1, sample: line });
+		} else {
+			existing.count += 1;
+		}
+	}
+
+	const clustered: Array<string> = [];
+	for (const [rule, { count, sample }] of counts) {
+		clustered.push(count > 1 ? `${sample}  (x${count}, rule: ${rule})` : sample);
+	}
+
+	const merged = [...clustered, ...ungrouped];
+	return {
+		lines: merged.slice(0, max),
+		totalIssues: errorLines.length,
+	};
 }
+
+function extractRule(line: string): string | undefined {
+	const trimmed = line.trim();
+	const match = RULE_TOKEN_PATTERN.exec(trimmed);
+	return match?.[1];
+}
+
+const LINT_COMMAND = "pnpm lint";
 
 export function buildHookOutput(
 	filePath: string,
-	errors: Array<string>,
+	errors: FormattedErrors,
 	debugInfo = "",
 ): PostToolUseHookOutput {
-	const errorText = errors.join("\n");
-	const isTruncated = errors.length >= MAX_ERRORS;
+	const remaining = errors.totalIssues - errors.lines.length;
+	const errorText = errors.lines.join("\n");
+	const overflowSuffix =
+		remaining > 0 ? `\n+ ${remaining} more issues — run \`${LINT_COMMAND}\` to see all` : "";
 
-	const userMessage = `⚠️ Lint errors in ${filePath}:\n${errorText}${isTruncated ? "\n..." : ""}${debugInfo}`;
-	const claudeMessage = `⚠️ Lint errors in ${filePath}:\n${errorText}${isTruncated ? "\n(run lint to view more)" : ""}${debugInfo}`;
+	const issueWord = errors.totalIssues === 1 ? "issue" : "issues";
+	const heading = `${filePath} shows ${errors.totalIssues} ${issueWord}:`;
+	const body = `${heading}\n${errorText}${overflowSuffix}${debugInfo}`;
+	const wrapped = `<workspace_diagnostics source="eslint">\n${body}\n</workspace_diagnostics>`;
 
 	return {
 		decision: undefined,
 		hookSpecificOutput: {
-			additionalContext: claudeMessage,
+			additionalContext: wrapped,
 			hookEventName: "PostToolUse",
 		},
-		systemMessage: userMessage,
+		systemMessage: wrapped,
 	};
 }
 
@@ -722,7 +767,7 @@ export function lint(
 	if (outputs.length > 0) {
 		const combined = outputs.join("\n");
 		const errors = formatErrors(combined);
-		if (errors.length > 0) {
+		if (errors.lines.length > 0) {
 			return buildHookOutput(filePath, errors, debugInfo);
 		}
 	}
@@ -776,6 +821,23 @@ export function main(targets: Array<string>, settings: LintSettings = DEFAULT_SE
 	if (hasErrors) {
 		process.exit(1);
 	}
+}
+
+function findImporters(filePath: string, runner = DEFAULT_SETTINGS.runner): Array<string> {
+	const absPath = resolve(filePath);
+	const sourceRoot = findSourceRoot(absPath);
+	if (sourceRoot === undefined) {
+		return [];
+	}
+
+	const entryPoints = findEntryPoints(sourceRoot);
+	if (entryPoints.length === 0) {
+		return [];
+	}
+
+	const graph = getDependencyGraph(sourceRoot, entryPoints, runner);
+	const targetRelative = relative(sourceRoot, absPath).replaceAll("\\", "/");
+	return invertGraph(graph, targetRelative).map((file) => join(sourceRoot, file));
 }
 
 function parseFrontmatter(content: string): Map<string, string> {
@@ -837,23 +899,6 @@ function createMarkerPath(): string {
 	const timestamp = Date.now();
 	const random = Math.random().toString(36).slice(2, 8);
 	return join(tmpdir(), `.eslint_d_${timestamp}_${random}.done`);
-}
-
-function findImporters(filePath: string, runner = DEFAULT_SETTINGS.runner): Array<string> {
-	const absPath = resolve(filePath);
-	const sourceRoot = findSourceRoot(absPath);
-	if (sourceRoot === undefined) {
-		return [];
-	}
-
-	const entryPoints = findEntryPoints(sourceRoot);
-	if (entryPoints.length === 0) {
-		return [];
-	}
-
-	const graph = getDependencyGraph(sourceRoot, entryPoints, runner);
-	const targetRelative = relative(sourceRoot, absPath).replaceAll("\\", "/");
-	return invertGraph(graph, targetRelative).map((file) => join(sourceRoot, file));
 }
 
 /* v8 ignore start -- CLI entrypoint */

--- a/test/lint.spec.ts
+++ b/test/lint.spec.ts
@@ -488,15 +488,17 @@ describe(lint, () => {
 
 	describe(formatErrors, () => {
 		it("should extract error lines from eslint output", () => {
-			expect.assertions(1);
+			expect.assertions(2);
 
 			const output = `${testErrorLine}\n  2:1  warning  no-console\n`;
+			const result = formatErrors(output);
 
-			expect(formatErrors(output)).toStrictEqual([testErrorLine]);
+			expect(result.lines).toStrictEqual([testErrorLine]);
+			expect(result.totalIssues).toBe(1);
 		});
 
-		it("should truncate to 5 errors max", () => {
-			expect.assertions(1);
+		it("should cap surfaced lines at the configured max", () => {
+			expect.assertions(2);
 
 			const lines = Array.from(
 				{ length: 10 },
@@ -506,36 +508,75 @@ describe(lint, () => {
 
 			const result = formatErrors(output);
 
-			expect(result).toHaveLength(5);
+			expect(result.lines).toHaveLength(5);
+			expect(result.totalIssues).toBe(10);
+		});
+
+		it("should cluster repeated rule violations into a single entry with count", () => {
+			expect.assertions(3);
+
+			const lines = Array.from(
+				{ length: 7 },
+				(_, index) => `  ${index}:1  error  no-explicit-any`,
+			);
+			const result = formatErrors(lines.join("\n"));
+
+			expect(result.lines).toHaveLength(1);
+			expect(result.lines[0]).toContain("(x7, rule: no-explicit-any)");
+			expect(result.totalIssues).toBe(7);
+		});
+
+		it("should preserve distinct rule lines without clustering", () => {
+			expect.assertions(2);
+
+			const output = [
+				"  1:5  error  no-unused-vars",
+				"  2:1  error  no-undef",
+				"  3:2  error  no-shadow",
+			].join("\n");
+			const result = formatErrors(output);
+
+			expect(result.lines).toHaveLength(3);
+			expect(result.totalIssues).toBe(3);
 		});
 	});
 
 	describe(buildHookOutput, () => {
-		it("should return correct hook JSON shape", () => {
-			expect.assertions(3);
+		it("should wrap output in workspace_diagnostics tag and use third-person voice", () => {
+			expect.assertions(5);
 
-			const result = buildHookOutput("foo.ts", [testErrorLine]);
+			const result = buildHookOutput("foo.ts", { lines: [testErrorLine], totalIssues: 1 });
 
 			expect(result).toMatchObject({
 				hookSpecificOutput: {
 					hookEventName: "PostToolUse",
 				},
 			});
-			expect(result.systemMessage).toContain("foo.ts");
-			expect(result.hookSpecificOutput!.additionalContext).toContain("foo.ts");
+			expect(result.systemMessage).toContain('<workspace_diagnostics source="eslint">');
+			expect(result.systemMessage).toContain("</workspace_diagnostics>");
+			expect(result.systemMessage).toContain("foo.ts shows 1 issue");
+			expect(result.systemMessage).not.toMatch(/\byou\b/i);
 		});
 
-		it("should truncate output when errors reach max", () => {
+		it("should append a cap-overflow notice when total issues exceed surfaced lines", () => {
 			expect.assertions(2);
 
-			const errors = Array.from(
+			const lines = Array.from(
 				{ length: 5 },
 				(_, index) => `  ${index}:1  error  rule-${index}`,
 			);
-			const result = buildHookOutput("foo.ts", errors);
+			const result = buildHookOutput("foo.ts", { lines, totalIssues: 12 });
 
-			expect(result.systemMessage).toContain("...");
-			expect(result.hookSpecificOutput!.additionalContext).toContain("run lint to view more");
+			expect(result.systemMessage).toContain("+ 7 more issues");
+			expect(result.hookSpecificOutput!.additionalContext).toContain("pnpm lint");
+		});
+
+		it("should omit overflow notice when totals match", () => {
+			expect.assertions(1);
+
+			const result = buildHookOutput("foo.ts", { lines: [testErrorLine], totalIssues: 1 });
+
+			expect(result.systemMessage).not.toContain("more issues");
 		});
 	});
 
@@ -1723,7 +1764,7 @@ describe(lint, () => {
 		});
 
 		it("should block when errors exist and attempts below max", () => {
-			expect.assertions(2);
+			expect.assertions(5);
 
 			const result = stopDecision({
 				errorFiles: ["src/foo.ts"],
@@ -1734,6 +1775,9 @@ describe(lint, () => {
 
 			expect(result?.decision).toBe("block");
 			expect(result?.reason).toContain("src/foo.ts");
+			expect(result?.reason).toContain('<workspace_diagnostics source="eslint">');
+			expect(result?.reason).toMatch(/\?\s*\n?<\/workspace_diagnostics>/);
+			expect(result?.reason).not.toMatch(/\byou\b/i);
 		});
 
 		it("should allow stop when all erroring files maxed out", () => {
@@ -1788,8 +1832,8 @@ describe(lint, () => {
 			expect(result).toMatchObject({ decision: "block" });
 		});
 
-		it("should allow stop after 3 stop attempts with user message", () => {
-			expect.assertions(2);
+		it("should allow stop after 3 stop attempts with informational reason", () => {
+			expect.assertions(4);
 
 			const result = stopDecision({
 				errorFiles: ["src/foo.ts"],
@@ -1799,7 +1843,9 @@ describe(lint, () => {
 			});
 
 			expect(result?.decision).toBeUndefined();
-			expect(result?.reason).toContain("Unresolved lint errors");
+			expect(result?.reason).toContain("Unresolved lint issues");
+			expect(result?.reason).toContain('<workspace_diagnostics source="eslint">');
+			expect(result?.reason).not.toMatch(/\byou\b/i);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Phase 1 of lint hook redesign — pure presentation changes to reduce sycophancy and context noise. Cadence behaviour is unchanged.

- Drops ALL-CAPS authoritative framing (`CRITICAL:`, `ERROR:`) on agent-facing strings, per Anthropic's current prompting guidance for Opus 4.5+ (\"Where you might have said 'CRITICAL: You MUST...', use more normal prompting\")
- Wraps surfaced diagnostics in `<workspace_diagnostics source=\"eslint\">…</workspace_diagnostics>` — low-authority structural framing as data, matching Cline's exact convention
- Switches to third-person declarative voice (\"X shows N issues\") and question-form for actionable prompts (\"…address before continuing?\"). Question-form reduces sycophancy ~24pp on Sonnet-4.5 / Opus per *Ask Don't Tell* (arXiv:2602.23971); replicates with smaller-but-nonzero effect on Opus 4.5+
- Cluster-deduplicates identical rule violations into a single entry with a count (e.g. `(x50, rule: ts/no-explicit-any)`) instead of emitting 50 separate lines
- Keeps the existing `MAX_ERRORS = 5` cap; appends `+ N more issues — run \`pnpm lint\` to see all` when exceeded. *FeedbackEval* (arXiv:2504.06939) shows benefit plateaus after 2-3 errors per cycle, so capping is real signal

## Out of scope (other phases)

- Settings schema additions (Phase 3) — `maxLintErrors` setting deliberately not added here; falls back to existing `5` constant
- State refactor (Phase 2) — runs in parallel; this PR doesn't touch state code
- Cadence changes (Phases 4–5)
- typecheck output reframe — getting disabled per the user's plan

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test --run` (167 tests pass)
- [x] New tests for: XML wrapping, third-person voice, cluster-dedup, error cap, overflow notice

## Files changed

- `hooks/lint.ts` — loop-warning prefix rewritten without `CRITICAL:`
- `scripts/lint.ts` — `formatErrors` returns `{ lines, totalIssues }` with cluster-dedup; `buildHookOutput` wraps in workspace_diagnostics tag, third-person voice, overflow notice; `stopDecision` reasons wrapped + question-form for block, declarative for inform
- `test/lint.spec.ts` — updated assertions, added cluster-dedup + voice + XML wrapping cases