### PR TITLE
refactor(state): composite-key edited-files state by (session_id, agent_id)

### DIFF
--- a/hooks/clear-lint-state.ts
+++ b/hooks/clear-lint-state.ts
@@ -1,6 +1,11 @@
 import type { SessionStartHookInput } from "@anthropic-ai/claude-agent-sdk";
 
-import { clearEditedFiles, clearLintAttempts, clearStopAttempts } from "../scripts/lint.ts";
+import {
+	clearEditedFiles,
+	clearLintAttempts,
+	clearStopAttempts,
+	getBucketKey,
+} from "../scripts/lint.ts";
 import { clearTypecheckStopAttempts } from "../scripts/type-check.ts";
 import { readStdinJson } from "./io.ts";
 
@@ -9,4 +14,4 @@ const input = await readStdinJson<SessionStartHookInput>();
 clearLintAttempts();
 clearStopAttempts();
 clearTypecheckStopAttempts();
-clearEditedFiles(input.session_id);
+clearEditedFiles(getBucketKey(input));

--- a/hooks/lint-stop.ts
+++ b/hooks/lint-stop.ts
@@ -6,6 +6,7 @@ import process from "node:process";
 
 import {
 	findSourceRoot,
+	getBucketKey,
 	getTransitiveDependents,
 	isLintableFile,
 	lint,
@@ -33,9 +34,9 @@ if (!settings.lint) {
 }
 
 const input = await readStdinJson<StopHookInput>();
-const SESSION_ID = input.session_id;
+const BUCKET_KEY = getBucketKey(input);
 
-const editedFiles = readEditedFiles(SESSION_ID);
+const editedFiles = readEditedFiles(BUCKET_KEY);
 debug(`editedFiles=${JSON.stringify(editedFiles)}`);
 if (editedFiles.length === 0) {
 	process.exit(0);

--- a/hooks/lint.ts
+++ b/hooks/lint.ts
@@ -3,6 +3,7 @@ import type { PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import process from "node:process";
 
 import {
+	getBucketKey,
 	isInProject,
 	lint,
 	readLintAttempts,
@@ -50,5 +51,5 @@ function run(filePath: string): void {
 
 if (isInProject(FILE_PATH)) {
 	run(FILE_PATH);
-	writeEditedFile(input.session_id, FILE_PATH);
+	writeEditedFile(getBucketKey(input), FILE_PATH);
 }

--- a/hooks/type-check-stop.ts
+++ b/hooks/type-check-stop.ts
@@ -6,6 +6,7 @@ import process from "node:process";
 
 import {
 	findSourceRoot,
+	getBucketKey,
 	getTransitiveDependents,
 	readEditedFiles,
 	readLintAttempts,
@@ -35,11 +36,11 @@ if (!settings.typecheck) {
 }
 
 const input = await readStdinJson<StopHookInput>();
-const SESSION_ID = input.session_id;
+const BUCKET_KEY = getBucketKey(input);
 
 const PROJECT_ROOT = process.env["CLAUDE_PROJECT_DIR"] ?? process.cwd();
 
-const editedFiles = readEditedFiles(SESSION_ID);
+const editedFiles = readEditedFiles(BUCKET_KEY);
 debug(`editedFiles=${JSON.stringify(editedFiles)}`);
 if (editedFiles.length === 0) {
 	process.exit(0);

--- a/hooks/type-check.ts
+++ b/hooks/type-check.ts
@@ -3,6 +3,7 @@ import type { PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import process from "node:process";
 
 import {
+	getBucketKey,
 	isInProject,
 	readLintAttempts,
 	readSettings,
@@ -49,5 +50,5 @@ function run(filePath: string): void {
 
 if (isInProject(FILE_PATH)) {
 	run(FILE_PATH);
-	writeEditedFile(input.session_id, FILE_PATH);
+	writeEditedFile(getBucketKey(input), FILE_PATH);
 }

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -1,4 +1,5 @@
 import type {
+	BaseHookInput,
 	PostToolUseHookSpecificOutput,
 	SyncHookJSONOutput,
 } from "@anthropic-ai/claude-agent-sdk";
@@ -82,58 +83,90 @@ const RESTART_DAEMON_LOG = ".claude/state/restartDaemon.log";
 const IS_RESTART_DAEMON_DEBUG = false as boolean;
 const CLAUDE_PID_PATH = ".claude/state/claude-pid";
 
-type EditedFilesState = Record<string, Array<string>>;
-
-export function readEditedFiles(sessionId: string): Array<string> {
-	if (!existsSync(EDITED_FILES_PATH)) {
-		return [];
-	}
-
-	try {
-		const state = JSON.parse(readFileSync(EDITED_FILES_PATH, "utf-8")) as EditedFilesState;
-		return state[sessionId] ?? [];
-	} catch {
-		return [];
-	}
+interface EditedFilesBucket {
+	edited: Array<string>;
+	lastSurfacedAt: null | number;
 }
 
-export function writeEditedFile(sessionId: string, filePath: string): void {
-	let state = {} satisfies EditedFilesState as EditedFilesState;
-	if (existsSync(EDITED_FILES_PATH)) {
-		try {
-			state = JSON.parse(readFileSync(EDITED_FILES_PATH, "utf-8")) as EditedFilesState;
-		} catch {
-			state = {} satisfies EditedFilesState as EditedFilesState;
-		}
+type EditedFilesState = Record<string, EditedFilesBucket>;
+
+/**
+ * Composite bucket key for state isolation between main thread and subagents.
+ * Returns `<session_id>:main` on the main thread, `<session_id>:<agent_id>` from
+ * inside a subagent. Subagents share `session_id` with the parent but get a
+ * distinct `agent_id`, so this composite cleanly partitions state.
+ *
+ * @param input - SDK hook input containing `session_id` and optional `agent_id`.
+ * @returns Bucket key suitable for the edited-files state map.
+ */
+export function getBucketKey(input: BaseHookInput): string {
+	return `${input.session_id}:${input.agent_id ?? "main"}`;
+}
+
+export function readEditedFiles(bucketKey: string): Array<string> {
+	const state = readState();
+	return state[bucketKey]?.edited ?? [];
+}
+
+export function writeEditedFile(bucketKey: string, filePath: string): void {
+	const state = readState();
+	const bucket = state[bucketKey] ?? { edited: [], lastSurfacedAt: null };
+	if (!bucket.edited.includes(filePath)) {
+		bucket.edited.push(filePath);
 	}
 
-	const files = state[sessionId] ?? [];
-	if (!files.includes(filePath)) {
-		files.push(filePath);
-	}
-
-	state[sessionId] = files;
+	state[bucketKey] = bucket;
 	mkdirSync(dirname(EDITED_FILES_PATH), { recursive: true });
 	writeFileSync(EDITED_FILES_PATH, JSON.stringify(state));
 }
 
-export function clearEditedFiles(sessionId: string): void {
+export function clearEditedFiles(bucketKey: string): void {
 	if (!existsSync(EDITED_FILES_PATH)) {
 		return;
 	}
 
+	let state: EditedFilesState;
 	try {
-		const state = JSON.parse(readFileSync(EDITED_FILES_PATH, "utf-8")) as EditedFilesState;
-		delete state[sessionId];
-
-		if (Object.keys(state).length === 0) {
-			unlinkSync(EDITED_FILES_PATH);
-		} else {
-			writeFileSync(EDITED_FILES_PATH, JSON.stringify(state));
-		}
+		state = JSON.parse(readFileSync(EDITED_FILES_PATH, "utf-8")) as unknown as EditedFilesState;
 	} catch {
 		unlinkSync(EDITED_FILES_PATH);
+		return;
 	}
+
+	if (!(bucketKey in state)) {
+		return;
+	}
+
+	delete state[bucketKey];
+
+	if (Object.keys(state).length === 0) {
+		unlinkSync(EDITED_FILES_PATH);
+	} else {
+		writeFileSync(EDITED_FILES_PATH, JSON.stringify(state));
+	}
+}
+
+/**
+ * Mark a bucket as surfaced at the given timestamp (defaults to now). Used by
+ * surface-gating logic to track which edits have already been reported to the
+ * agent. Hooks call this after emitting a diagnostics surface so subsequent
+ * surfaces only include edits made since.
+ *
+ * @param bucketKey - Bucket to mark; see {@link getBucketKey}.
+ * @param timestamp - Surface time in ms since epoch; defaults to `Date.now()`.
+ */
+export function markBucketSurfaced(bucketKey: string, timestamp: number = Date.now()): void {
+	const state = readState();
+	const bucket = state[bucketKey] ?? { edited: [], lastSurfacedAt: null };
+	bucket.lastSurfacedAt = timestamp;
+	state[bucketKey] = bucket;
+	mkdirSync(dirname(EDITED_FILES_PATH), { recursive: true });
+	writeFileSync(EDITED_FILES_PATH, JSON.stringify(state));
+}
+
+export function getLastSurfacedAt(bucketKey: string): null | number {
+	const state = readState();
+	return state[bucketKey]?.lastSurfacedAt ?? null;
 }
 
 export function getTransitiveDependents(
@@ -179,6 +212,18 @@ export function getTransitiveDependents(
 	return [...visited]
 		.filter((file) => !originals.has(file))
 		.map((file) => join(sourceRoot, file));
+}
+
+function readState(): EditedFilesState {
+	if (!existsSync(EDITED_FILES_PATH)) {
+		return {};
+	}
+
+	try {
+		return JSON.parse(readFileSync(EDITED_FILES_PATH, "utf-8")) as unknown as EditedFilesState;
+	} catch {
+		return {};
+	}
 }
 
 function getClaudePid(): string | undefined {

--- a/test/lint.spec.ts
+++ b/test/lint.spec.ts
@@ -1,3 +1,5 @@
+import type { BaseHookInput } from "@anthropic-ai/claude-agent-sdk";
+
 import { createFromFile } from "file-entry-cache";
 import type { ChildProcess, execFileSync, spawnSync } from "node:child_process";
 import { execSync, spawn } from "node:child_process";
@@ -25,8 +27,10 @@ import {
 	findEntryPoints,
 	findSourceRoot,
 	formatErrors,
+	getBucketKey,
 	getChangedFiles,
 	getDependencyGraph,
+	getLastSurfacedAt,
 	getTransitiveDependents,
 	invalidateCacheEntries,
 	invertGraph,
@@ -35,6 +39,7 @@ import {
 	isProtectedFile,
 	lint,
 	main,
+	markBucketSurfaced,
 	readEditedFiles,
 	readLintAttempts,
 	readSettings,
@@ -1885,33 +1890,67 @@ describe(lint, () => {
 		});
 	});
 
+	describe(getBucketKey, () => {
+		it("should return <session_id>:main when agent_id is absent", () => {
+			expect.assertions(1);
+
+			const input = {
+				cwd: "/project",
+				session_id: "abc123",
+				transcript_path: "/tmp/t.json",
+			} satisfies BaseHookInput;
+
+			expect(getBucketKey(input)).toBe("abc123:main");
+		});
+
+		it("should return <session_id>:<agent_id> when agent_id is present", () => {
+			expect.assertions(1);
+
+			const input = {
+				agent_id: "agent_xyz",
+				cwd: "/project",
+				session_id: "abc123",
+				transcript_path: "/tmp/t.json",
+			} satisfies BaseHookInput;
+
+			expect(getBucketKey(input)).toBe("abc123:agent_xyz");
+		});
+	});
+
 	describe(readEditedFiles, () => {
 		it("should return empty array when file missing", () => {
 			expect.assertions(1);
 
 			mockedExistsSync.mockReturnValue(false);
 
-			expect(readEditedFiles("session-1")).toStrictEqual([]);
+			expect(readEditedFiles("abc123:main")).toStrictEqual([]);
 		});
 
-		it("should return files for the given session", () => {
+		it("should return files for the given bucket", () => {
 			expect.assertions(1);
 
 			mockedExistsSync.mockReturnValue(true);
 			mockedReadFileSync.mockReturnValue(
-				JSON.stringify({ "session-1": ["src/foo.ts"], "session-2": ["src/bar.ts"] }),
+				JSON.stringify({
+					"abc123:agent_xyz": { edited: ["src/bar.ts"], lastSurfacedAt: null },
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
 			);
 
-			expect(readEditedFiles("session-1")).toStrictEqual(["src/foo.ts"]);
+			expect(readEditedFiles("abc123:main")).toStrictEqual(["src/foo.ts"]);
 		});
 
-		it("should return empty array for unknown session", () => {
+		it("should return empty array for unknown bucket", () => {
 			expect.assertions(1);
 
 			mockedExistsSync.mockReturnValue(true);
-			mockedReadFileSync.mockReturnValue(JSON.stringify({ "session-1": ["src/foo.ts"] }));
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
+			);
 
-			expect(readEditedFiles("session-unknown")).toStrictEqual([]);
+			expect(readEditedFiles("zzz:main")).toStrictEqual([]);
 		});
 
 		it("should return empty array on corrupt JSON", () => {
@@ -1920,64 +1959,202 @@ describe(lint, () => {
 			mockedExistsSync.mockReturnValue(true);
 			mockedReadFileSync.mockReturnValue("{bad json");
 
-			expect(readEditedFiles("session-1")).toStrictEqual([]);
+			expect(readEditedFiles("abc123:main")).toStrictEqual([]);
 		});
 	});
 
 	describe(writeEditedFile, () => {
-		it("should create state file with session entry", () => {
+		it("should create state file with bucket entry", () => {
 			expect.assertions(1);
 
 			mockedExistsSync.mockReturnValue(false);
 
-			writeEditedFile("session-1", "src/foo.ts");
+			writeEditedFile("abc123:main", "src/foo.ts");
 
 			expect(mockedWriteFileSync).toHaveBeenCalledWith(
 				".claude/state/edited-files.json",
-				JSON.stringify({ "session-1": ["src/foo.ts"] }),
+				JSON.stringify({
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
 			);
 		});
 
-		it("should append to existing session entry", () => {
+		it("should append to existing bucket entry", () => {
 			expect.assertions(1);
 
 			mockedExistsSync.mockReturnValue(true);
-			mockedReadFileSync.mockReturnValue(JSON.stringify({ "session-1": ["src/foo.ts"] }));
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
+			);
 
-			writeEditedFile("session-1", "src/bar.ts");
+			writeEditedFile("abc123:main", "src/bar.ts");
 
 			expect(mockedWriteFileSync).toHaveBeenCalledWith(
 				".claude/state/edited-files.json",
-				JSON.stringify({ "session-1": ["src/foo.ts", "src/bar.ts"] }),
+				JSON.stringify({
+					"abc123:main": { edited: ["src/foo.ts", "src/bar.ts"], lastSurfacedAt: null },
+				}),
 			);
 		});
 
-		it("should deduplicate files within a session", () => {
+		it("should deduplicate files within a bucket", () => {
 			expect.assertions(1);
 
 			mockedExistsSync.mockReturnValue(true);
-			mockedReadFileSync.mockReturnValue(JSON.stringify({ "session-1": ["src/foo.ts"] }));
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
+			);
 
-			writeEditedFile("session-1", "src/foo.ts");
+			writeEditedFile("abc123:main", "src/foo.ts");
 
 			expect(mockedWriteFileSync).toHaveBeenCalledWith(
 				".claude/state/edited-files.json",
-				JSON.stringify({ "session-1": ["src/foo.ts"] }),
+				JSON.stringify({
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
 			);
 		});
 
-		it("should not interfere with other sessions", () => {
+		it("should not interfere with sibling buckets in the same session", () => {
+			expect.assertions(1);
+
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
+			);
+
+			writeEditedFile("abc123:agent_xyz", "src/bar.ts");
+
+			const lastCall = mockedWriteFileSync.mock.lastCall!;
+			const writtenState = JSON.parse(lastCall[1] as string) as Record<string, unknown>;
+
+			expect(writtenState).toStrictEqual({
+				"abc123:agent_xyz": { edited: ["src/bar.ts"], lastSurfacedAt: null },
+				"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+			});
+		});
+
+		it("should preserve lastSurfacedAt across writes", () => {
 			expect.assertions(1);
 
 			mockedExistsSync.mockReturnValue(true);
-			mockedReadFileSync.mockReturnValue(JSON.stringify({ "session-1": ["src/foo.ts"] }));
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: 1000 },
+				}),
+			);
 
-			writeEditedFile("session-2", "src/bar.ts");
+			writeEditedFile("abc123:main", "src/bar.ts");
 
 			expect(mockedWriteFileSync).toHaveBeenCalledWith(
 				".claude/state/edited-files.json",
-				JSON.stringify({ "session-1": ["src/foo.ts"], "session-2": ["src/bar.ts"] }),
+				JSON.stringify({
+					"abc123:main": { edited: ["src/foo.ts", "src/bar.ts"], lastSurfacedAt: 1000 },
+				}),
 			);
+		});
+	});
+
+	describe("composite-key isolation", () => {
+		it("should not leak edits between main and subagent buckets", () => {
+			expect.assertions(2);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"abc123:agent_xyz": { edited: ["src/bar.ts"], lastSurfacedAt: null },
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
+			);
+
+			expect(readEditedFiles("abc123:main")).toStrictEqual(["src/foo.ts"]);
+			expect(readEditedFiles("abc123:agent_xyz")).toStrictEqual(["src/bar.ts"]);
+		});
+
+		it("should round-trip writes to two buckets via mocked file", () => {
+			expect.assertions(2);
+
+			let stored = "{}";
+			mockedExistsSync.mockImplementation(
+				(path) => path === ".claude/state/edited-files.json",
+			);
+			mockedReadFileSync.mockImplementation(() => stored);
+			mockedWriteFileSync.mockImplementation((_path, content) => {
+				stored = content as string;
+			});
+
+			writeEditedFile("abc123:main", "src/foo.ts");
+			writeEditedFile("abc123:agent_xyz", "src/bar.ts");
+
+			expect(readEditedFiles("abc123:main")).toStrictEqual(["src/foo.ts"]);
+			expect(readEditedFiles("abc123:agent_xyz")).toStrictEqual(["src/bar.ts"]);
+		});
+	});
+
+	describe(markBucketSurfaced, () => {
+		it("should set lastSurfacedAt on existing bucket", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
+			);
+
+			markBucketSurfaced("abc123:main", 12_345);
+
+			expect(mockedWriteFileSync).toHaveBeenCalledWith(
+				".claude/state/edited-files.json",
+				JSON.stringify({
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: 12_345 },
+				}),
+			);
+		});
+
+		it("should create empty bucket when none exists", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(false);
+
+			markBucketSurfaced("abc123:main", 12_345);
+
+			expect(mockedWriteFileSync).toHaveBeenCalledWith(
+				".claude/state/edited-files.json",
+				JSON.stringify({
+					"abc123:main": { edited: [], lastSurfacedAt: 12_345 },
+				}),
+			);
+		});
+	});
+
+	describe(getLastSurfacedAt, () => {
+		it("should return null when bucket missing", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(false);
+
+			expect(getLastSurfacedAt("abc123:main")).toBeNull();
+		});
+
+		it("should return stored timestamp", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"abc123:main": { edited: [], lastSurfacedAt: 9999 },
+				}),
+			);
+
+			expect(getLastSurfacedAt("abc123:main")).toBe(9999);
 		});
 	});
 
@@ -1988,37 +2165,46 @@ describe(lint, () => {
 			mockedUnlinkSync.mockClear();
 			mockedExistsSync.mockReturnValue(false);
 
-			clearEditedFiles("session-1");
+			clearEditedFiles("abc123:main");
 
 			expect(mockedUnlinkSync).not.toHaveBeenCalled();
 		});
 
-		it("should delete file when session is the only entry", () => {
+		it("should delete file when bucket is the only entry", () => {
 			expect.assertions(1);
 
 			mockedUnlinkSync.mockClear();
 			mockedExistsSync.mockReturnValue(true);
-			mockedReadFileSync.mockReturnValue(JSON.stringify({ "session-1": ["src/foo.ts"] }));
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
+			);
 
-			clearEditedFiles("session-1");
+			clearEditedFiles("abc123:main");
 
 			expect(mockedUnlinkSync).toHaveBeenCalledWith(".claude/state/edited-files.json");
 		});
 
-		it("should keep file with remaining sessions", () => {
+		it("should keep file with remaining buckets", () => {
 			expect.assertions(1);
 
 			mockedWriteFileSync.mockClear();
 			mockedExistsSync.mockReturnValue(true);
 			mockedReadFileSync.mockReturnValue(
-				JSON.stringify({ "session-1": ["src/foo.ts"], "session-2": ["src/bar.ts"] }),
+				JSON.stringify({
+					"abc123:agent_xyz": { edited: ["src/bar.ts"], lastSurfacedAt: null },
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
 			);
 
-			clearEditedFiles("session-1");
+			clearEditedFiles("abc123:main");
 
 			expect(mockedWriteFileSync).toHaveBeenCalledWith(
 				".claude/state/edited-files.json",
-				JSON.stringify({ "session-2": ["src/bar.ts"] }),
+				JSON.stringify({
+					"abc123:agent_xyz": { edited: ["src/bar.ts"], lastSurfacedAt: null },
+				}),
 			);
 		});
 
@@ -2029,7 +2215,7 @@ describe(lint, () => {
 			mockedExistsSync.mockReturnValue(true);
 			mockedReadFileSync.mockReturnValue("{bad");
 
-			clearEditedFiles("session-1");
+			clearEditedFiles("abc123:main");
 
 			expect(mockedUnlinkSync).toHaveBeenCalledWith(".claude/state/edited-files.json");
 		});


### PR DESCRIPTION
## Summary

Refactor `edited-files.json` state to be keyed by composite `(session_id, agent_id ?? "main")` so subagent edits are isolated from main-thread edits.

## Why

`session_id` stays constant across parent + subagents (per Anthropic docs). `agent_id` is the per-subagent discriminator on `BaseHookInput` (typed via `@anthropic-ai/claude-agent-sdk`). Composite keying lets `SubagentStop` lint only that subagent's edits and `Stop` lint only main-thread edits, without cross-contamination — foundation for the upcoming tiered cadence work (Phases 4-5).

## Changes

- New `getBucketKey(input: BaseHookInput): string` helper returning `${session_id}:${agent_id ?? "main"}`
- `readEditedFiles` / `writeEditedFile` / `clearEditedFiles` take a bucket key instead of a session_id
- `markBucketSurfaced` / `getLastSurfacedAt` exports — wired by Phase 4-5 cadence work, unused for now
- Schema: `{ [bucketKey]: { edited: string[], lastSurfacedAt: number | null } }` — forward-compatible with surface-gating marker without a future schema flip
- Call sites updated in `hooks/lint.ts`, `hooks/lint-stop.ts`, `hooks/type-check.ts`, `hooks/type-check-stop.ts`, `hooks/clear-lint-state.ts`

## ⚠️ Operations note

**Delete `.claude/state/edited-files.json` after merging this branch.** The old shape (`{ [session_id]: filePaths[] }`) is no longer recognised. If a stale file with the old shape exists, `readState` will return `{}` (the parse-error catch swallows it) — no crash, but a one-shot state loss for any in-flight session. The state files are short-lived and regenerate on next edit, so impact is minimal.

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (176 tests; +3 from PR #7's reframe tests)
- [x] `pnpm build` passes
- [x] Round-trip test: write under main bucket + subagent bucket, read both back independently
- [x] Cross-bucket isolation test: writing one doesn't leak into the other
- [x] `getBucketKey` returns `<id>:main` when `agent_id` absent, `<id>:<agent_id>` when present

## Follow-ups for later phases (intentionally out of scope)

- `clear-lint-state.ts` doesn't garbage-collect stale subagent buckets across sessions; sweep is cheap once `lastSurfacedAt` cadence lands
- `markBucketSurfaced` / `getLastSurfacedAt` are exported but unused — wiring is Phase 4-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)