### PR TITLE
feat(lint): add cadence settings schema

### DIFF
--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -19,12 +19,19 @@ import { tmpdir } from "node:os";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import process from "node:process";
 
+export type LintCadence = "stop-only" | "strict" | "tiered";
+
+export const LINT_CADENCE_VALUES: ReadonlyArray<LintCadence> = ["stop-only", "strict", "tiered"];
+
 export interface LintSettings {
 	cacheBust: Array<string>;
 	debug: boolean;
 	eslint: boolean;
 	lint: boolean;
+	lintAutoFixOnBatch: boolean;
+	lintCadence: LintCadence;
 	maxLintAttempts: number;
+	maxLintErrors: number;
 	oxlint: boolean;
 	runner: string;
 	typecheck: boolean;
@@ -272,7 +279,6 @@ while ($currentPid -and $currentPid -ne 0) {
 const ESLINT_CACHE_PATH = ".eslintcache";
 const DEFAULT_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".mts", ".json"];
 const ENTRY_CANDIDATES = ["index.ts", "cli.ts", "main.ts"];
-const MAX_ERRORS = 5;
 
 const SETTINGS_FILE = ".claude/sentinel.local.md";
 
@@ -280,13 +286,18 @@ export const DEFAULT_CACHE_BUST = ["*.config.*", "**/tsconfig*.json"];
 
 const DEFAULT_MAX_LINT_ATTEMPTS = 1;
 const DEFAULT_MAX_STOP_ATTEMPTS = 1;
+const DEFAULT_MAX_LINT_ERRORS = 10;
+const DEFAULT_LINT_CADENCE: LintCadence = "strict";
 
 const DEFAULT_SETTINGS = {
 	cacheBust: [...DEFAULT_CACHE_BUST],
 	debug: false,
 	eslint: true,
 	lint: true,
+	lintAutoFixOnBatch: true,
+	lintCadence: DEFAULT_LINT_CADENCE,
 	maxLintAttempts: DEFAULT_MAX_LINT_ATTEMPTS,
+	maxLintErrors: DEFAULT_MAX_LINT_ERRORS,
 	oxlint: false,
 	runner: "pnpm exec",
 	typecheck: true,
@@ -331,12 +342,28 @@ export function readSettings(): LintSettings {
 	const maxLintAttempts =
 		maxAttemptsRaw !== undefined ? Number(maxAttemptsRaw) : DEFAULT_MAX_LINT_ATTEMPTS;
 
+	const maxErrorsRaw = fields.get("max-lint-errors");
+	const maxErrorsParsed = maxErrorsRaw !== undefined ? Number(maxErrorsRaw) : Number.NaN;
+	const maxLintErrors = Number.isFinite(maxErrorsParsed)
+		? maxErrorsParsed
+		: DEFAULT_MAX_LINT_ERRORS;
+
+	const cadenceRaw = fields.get("lint-cadence");
+	const lintCadence: LintCadence =
+		cadenceRaw !== undefined &&
+		(LINT_CADENCE_VALUES as ReadonlyArray<string>).includes(cadenceRaw)
+			? (cadenceRaw as LintCadence)
+			: DEFAULT_LINT_CADENCE;
+
 	return {
 		cacheBust: [...DEFAULT_CACHE_BUST, ...userPatterns],
 		debug: fields.get("debug") === "true",
 		eslint: fields.get("eslint") !== "false",
 		lint: fields.get("lint") !== "false",
+		lintAutoFixOnBatch: parseAutoFixOnBatch(fields.get("lint-auto-fix-on-batch")),
+		lintCadence,
 		maxLintAttempts,
+		maxLintErrors,
 		oxlint: fields.get("oxlint") === "true",
 		runner: fields.get("runner") ?? DEFAULT_SETTINGS.runner,
 		typecheck: fields.get("typecheck") !== "false",
@@ -696,7 +723,7 @@ setTimeout(() => {
 
 const RULE_TOKEN_PATTERN = /([\w-]+\/[\w-]+|[\w-]+)$/;
 
-export function formatErrors(output: string, max = MAX_ERRORS): FormattedErrors {
+export function formatErrors(output: string, max = DEFAULT_MAX_LINT_ERRORS): FormattedErrors {
 	const errorLines = output.split("\n").filter((line) => /error/i.test(line));
 
 	const counts = new Map<string, { count: number; sample: string }>();
@@ -883,6 +910,18 @@ function findImporters(filePath: string, runner = DEFAULT_SETTINGS.runner): Arra
 	const graph = getDependencyGraph(sourceRoot, entryPoints, runner);
 	const targetRelative = relative(sourceRoot, absPath).replaceAll("\\", "/");
 	return invertGraph(graph, targetRelative).map((file) => join(sourceRoot, file));
+}
+
+function parseAutoFixOnBatch(raw: string | undefined): boolean {
+	if (raw === "true") {
+		return true;
+	}
+
+	if (raw === "false") {
+		return false;
+	}
+
+	return DEFAULT_SETTINGS.lintAutoFixOnBatch;
 }
 
 function parseFrontmatter(content: string): Map<string, string> {

--- a/test/lint.spec.ts
+++ b/test/lint.spec.ts
@@ -506,15 +506,15 @@ describe(lint, () => {
 			expect.assertions(2);
 
 			const lines = Array.from(
-				{ length: 10 },
+				{ length: 15 },
 				(_, index) => `  ${index}:1  error  rule-${index}`,
 			);
 			const output = lines.join("\n");
 
 			const result = formatErrors(output);
 
-			expect(result.lines).toHaveLength(5);
-			expect(result.totalIssues).toBe(10);
+			expect(result.lines).toHaveLength(10);
+			expect(result.totalIssues).toBe(15);
 		});
 
 		it("should cluster repeated rule violations into a single entry with count", () => {
@@ -642,7 +642,10 @@ describe(lint, () => {
 				debug: false,
 				eslint: true,
 				lint: true,
+				lintAutoFixOnBatch: true,
+				lintCadence: "strict",
 				maxLintAttempts: 1,
+				maxLintErrors: 10,
 				oxlint: false,
 				runner: "pnpm exec",
 				typecheck: true,
@@ -661,7 +664,10 @@ describe(lint, () => {
 				debug: false,
 				eslint: true,
 				lint: true,
+				lintAutoFixOnBatch: true,
+				lintCadence: "strict",
 				maxLintAttempts: 1,
+				maxLintErrors: 10,
 				oxlint: false,
 				runner: "pnpm exec",
 				typecheck: true,
@@ -691,12 +697,78 @@ describe(lint, () => {
 				debug: false,
 				eslint: false,
 				lint: true,
+				lintAutoFixOnBatch: true,
+				lintCadence: "strict",
 				maxLintAttempts: 1,
+				maxLintErrors: 10,
 				oxlint: true,
 				runner: "pnpm exec",
 				typecheck: true,
 				typecheckArgs: [],
 			});
+		});
+
+		it("should parse lint-cadence: tiered", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue('---\nlint-cadence: "tiered"\n---\n');
+
+			expect(readSettings()).toMatchObject({ lintCadence: "tiered" });
+		});
+
+		it("should parse lint-cadence: stop-only", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue('---\nlint-cadence: "stop-only"\n---\n');
+
+			expect(readSettings()).toMatchObject({ lintCadence: "stop-only" });
+		});
+
+		it("should fall back to strict when lint-cadence is invalid", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue('---\nlint-cadence: "nonsense"\n---\n');
+
+			expect(readSettings()).toMatchObject({ lintCadence: "strict" });
+		});
+
+		it("should parse max-lint-errors as a number", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue('---\nmax-lint-errors: "20"\n---\n');
+
+			expect(readSettings()).toMatchObject({ maxLintErrors: 20 });
+		});
+
+		it("should fall back to default when max-lint-errors is non-numeric", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue('---\nmax-lint-errors: "abc"\n---\n');
+
+			expect(readSettings()).toMatchObject({ maxLintErrors: 10 });
+		});
+
+		it("should parse lint-auto-fix-on-batch: false", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue('---\nlint-auto-fix-on-batch: "false"\n---\n');
+
+			expect(readSettings()).toMatchObject({ lintAutoFixOnBatch: false });
+		});
+
+		it("should fall back to default when lint-auto-fix-on-batch is invalid", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue('---\nlint-auto-fix-on-batch: "maybe"\n---\n');
+
+			expect(readSettings()).toMatchObject({ lintAutoFixOnBatch: true });
 		});
 	});
 
@@ -912,7 +984,10 @@ describe(lint, () => {
 				debug: false,
 				eslint: false,
 				lint: true,
+				lintAutoFixOnBatch: true,
+				lintCadence: "strict",
 				maxLintAttempts: 1,
+				maxLintErrors: 10,
 				oxlint: true,
 				runner: "pnpm exec",
 				typecheck: true,
@@ -950,7 +1025,10 @@ describe(lint, () => {
 				debug: false,
 				eslint: false,
 				lint: true,
+				lintAutoFixOnBatch: true,
+				lintCadence: "strict",
 				maxLintAttempts: 1,
+				maxLintErrors: 10,
 				oxlint: true,
 				runner: "pnpm exec",
 				typecheck: true,
@@ -1165,7 +1243,10 @@ describe(lint, () => {
 				debug: false,
 				eslint: false,
 				lint: true,
+				lintAutoFixOnBatch: true,
+				lintCadence: "strict",
 				maxLintAttempts: 1,
+				maxLintErrors: 10,
 				oxlint: true,
 				runner: "pnpm exec",
 				typecheck: true,
@@ -1217,7 +1298,10 @@ describe(lint, () => {
 				debug: false,
 				eslint: true,
 				lint: true,
+				lintAutoFixOnBatch: true,
+				lintCadence: "strict",
 				maxLintAttempts: 1,
+				maxLintErrors: 10,
 				oxlint: true,
 				runner: "pnpm exec",
 				typecheck: true,
@@ -1251,7 +1335,10 @@ describe(lint, () => {
 				debug: false,
 				eslint: false,
 				lint: true,
+				lintAutoFixOnBatch: true,
+				lintCadence: "strict",
 				maxLintAttempts: 1,
+				maxLintErrors: 10,
 				oxlint: false,
 				runner: "pnpm exec",
 				typecheck: true,
@@ -1551,7 +1638,10 @@ describe(lint, () => {
 				debug: false,
 				eslint: true,
 				lint: true,
+				lintAutoFixOnBatch: true,
+				lintCadence: "strict",
 				maxLintAttempts: 1,
+				maxLintErrors: 10,
 				oxlint: false,
 				runner: "pnpm exec",
 				typecheck: true,
@@ -1577,7 +1667,10 @@ describe(lint, () => {
 				debug: false,
 				eslint: true,
 				lint: true,
+				lintAutoFixOnBatch: true,
+				lintCadence: "strict",
 				maxLintAttempts: 1,
+				maxLintErrors: 10,
 				oxlint: false,
 				runner: "pnpm exec",
 				typecheck: true,


### PR DESCRIPTION
## Summary

Add three settings fields to gate the upcoming tiered cadence work (Phases 4-5). Defaults preserve current behaviour; **no hooks change in this PR**.

## New settings

- **`lintCadence: "strict" | "tiered" | "stop-only"`** — default `"strict"`. Validated at read time; invalid values fall back to default. `tiered` and `stop-only` are valid but not yet wired (Phases 4-5).
- **`lintAutoFixOnBatch: boolean`** — default `true`. Will gate the PostToolBatch `--fix` hook in Phase 4. Unused in strict mode.
- **`maxLintErrors: number`** — default `10` (was 5 inline in `formatErrors`).

## Notable behaviour change

The `MAX_ERRORS = 5` constant in `formatErrors` is replaced with `DEFAULT_MAX_LINT_ERRORS = 10`. **In strict mode, this means more errors surfaced per edit (10 instead of 5).** Accepted because surfacing is moving to end-of-task in tiered mode anyway, where 10 makes more sense. User explicitly approved.

## Frontmatter keys

`sentinel.local.md` consumers can now set:
```
---
lint-cadence: "tiered"
lint-auto-fix-on-batch: "false"
max-lint-errors: "20"
---
```

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (183 tests; +7 new)
- [x] `pnpm build` passes
- [x] Default values when settings file absent or fields omitted
- [x] Valid `lintCadence` values parsed (`tiered`, `stop-only`)
- [x] Invalid `lintCadence` falls back to `strict`
- [x] `maxLintErrors` accepts numbers; non-number falls back to default
- [x] `lintAutoFixOnBatch: false` parsed; invalid value falls back to default

🤖 Generated with [Claude Code](https://claude.com/claude-code)