### PR TITLE
chore(types): add narrowToolInput helper for Edit/Write tool hooks

### DIFF
--- a/hooks/lint-guard.ts
+++ b/hooks/lint-guard.ts
@@ -2,14 +2,13 @@ import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 
 import { basename } from "node:path";
 
-import { isProtectedFile } from "../scripts/lint.ts";
+import { isProtectedFile, narrowToolInput } from "../scripts/lint.ts";
 import { readStdinJson, writeStdoutJson } from "./io.ts";
 
 const input = await readStdinJson<PreToolUseHookInput>();
 
 if (input.tool_name === "Write" || input.tool_name === "Edit") {
-	// eslint-disable-next-line ts/no-non-null-assertion -- Edit/Write tool_input always has file_path
-	const filePath = (input.tool_input as Record<string, string>)["file_path"]!;
+	const filePath = narrowToolInput(input).file_path;
 	const fileName = basename(filePath);
 	if (isProtectedFile(fileName)) {
 		writeStdoutJson({

--- a/hooks/lint.ts
+++ b/hooks/lint.ts
@@ -6,6 +6,7 @@ import {
 	getBucketKey,
 	isInProject,
 	lint,
+	narrowToolInput,
 	readLintAttempts,
 	readSettings,
 	writeEditedFile,
@@ -25,8 +26,7 @@ if (input.tool_name !== "Write" && input.tool_name !== "Edit") {
 	process.exit(0);
 }
 
-// eslint-disable-next-line ts/no-non-null-assertion -- Edit/Write tool_input always has file_path
-const FILE_PATH = (input.tool_input as Record<string, string>)["file_path"]!;
+const FILE_PATH = narrowToolInput(input).file_path;
 
 function run(filePath: string): void {
 	const attempts = readLintAttempts();

--- a/hooks/type-check.ts
+++ b/hooks/type-check.ts
@@ -5,6 +5,7 @@ import process from "node:process";
 import {
 	getBucketKey,
 	isInProject,
+	narrowToolInput,
 	readLintAttempts,
 	readSettings,
 	writeEditedFile,
@@ -25,8 +26,7 @@ if (input.tool_name !== "Write" && input.tool_name !== "Edit") {
 	process.exit(0);
 }
 
-// eslint-disable-next-line ts/no-non-null-assertion -- Edit/Write tool_input always has file_path
-const FILE_PATH = (input.tool_input as Record<string, string>)["file_path"]!;
+const FILE_PATH = narrowToolInput(input).file_path;
 
 function run(filePath: string): void {
 	const attempts = readLintAttempts();

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -3,6 +3,7 @@ import type {
 	PostToolUseHookSpecificOutput,
 	SyncHookJSONOutput,
 } from "@anthropic-ai/claude-agent-sdk";
+import type { FileEditInput, FileWriteInput } from "@anthropic-ai/claude-agent-sdk/sdk-tools";
 
 import { createFromFile } from "file-entry-cache";
 import { execFileSync, execSync, spawn, spawnSync } from "node:child_process";
@@ -97,6 +98,15 @@ interface EditedFilesBucket {
 
 type EditedFilesState = Record<string, EditedFilesBucket>;
 
+interface EditOrWriteHookInput {
+	// eslint-disable-next-line flawless/naming-convention -- mirrors SDK shape
+	tool_input: unknown;
+	// eslint-disable-next-line flawless/naming-convention -- mirrors SDK shape
+	tool_name: string;
+}
+
+type FilePathInput = Pick<FileEditInput | FileWriteInput, "file_path">;
+
 /**
  * Composite bucket key for state isolation between main thread and subagents.
  * Returns `<session_id>:main` on the main thread, `<session_id>:<agent_id>` from
@@ -108,6 +118,35 @@ type EditedFilesState = Record<string, EditedFilesBucket>;
  */
 export function getBucketKey(input: BaseHookInput): string {
 	return `${input.session_id}:${input.agent_id ?? "main"}`;
+}
+
+/**
+ * Narrows `tool_input` for `Edit`/`Write` tool hooks. Both tools always
+ * populate `file_path`, but the SDK types `tool_input` as `unknown` so this
+ * helper restores the discriminated shape with a runtime check.
+ *
+ * Caller must verify `input.tool_name` is `"Edit"` or `"Write"` first.
+ *
+ * @param input - SDK hook input narrowed to `Edit` or `Write` tools.
+ * @returns Object containing the validated `file_path` string.
+ * @throws If `tool_input` is not an object or `file_path` is missing or empty.
+ */
+export function narrowToolInput(input: EditOrWriteHookInput): FilePathInput {
+	const toolInput = input.tool_input;
+	if (typeof toolInput !== "object" || toolInput === null) {
+		throw new TypeError(
+			`Expected ${input.tool_name} tool_input to be an object, got ${typeof toolInput}`,
+		);
+	}
+
+	const filePath = (toolInput as Record<string, unknown>)["file_path"];
+	if (typeof filePath !== "string" || filePath === "") {
+		throw new TypeError(
+			`Expected ${input.tool_name} tool_input.file_path to be a non-empty string`,
+		);
+	}
+
+	return { file_path: filePath };
 }
 
 export function readEditedFiles(bucketKey: string): Array<string> {

--- a/test/lint.spec.ts
+++ b/test/lint.spec.ts
@@ -40,6 +40,7 @@ import {
 	lint,
 	main,
 	markBucketSurfaced,
+	narrowToolInput,
 	readEditedFiles,
 	readLintAttempts,
 	readSettings,
@@ -2007,6 +2008,70 @@ describe(lint, () => {
 			} satisfies BaseHookInput;
 
 			expect(getBucketKey(input)).toBe("abc123:agent_xyz");
+		});
+	});
+
+	describe(narrowToolInput, () => {
+		it("should return file_path for valid Edit input", () => {
+			expect.assertions(1);
+
+			const result = narrowToolInput({
+				tool_input: { file_path: "/project/src/foo.ts" },
+				tool_name: "Edit",
+			});
+
+			expect(result.file_path).toBe("/project/src/foo.ts");
+		});
+
+		it("should return file_path for valid Write input", () => {
+			expect.assertions(1);
+
+			const result = narrowToolInput({
+				tool_input: { content: "x", file_path: "/project/src/bar.ts" },
+				tool_name: "Write",
+			});
+
+			expect(result.file_path).toBe("/project/src/bar.ts");
+		});
+
+		it("should throw when tool_input is not an object", () => {
+			expect.assertions(1);
+
+			expect(() => {
+				narrowToolInput({ tool_input: "not-an-object", tool_name: "Edit" });
+			}).toThrowError(TypeError);
+		});
+
+		it("should throw when tool_input is null", () => {
+			expect.assertions(1);
+
+			expect(() => {
+				narrowToolInput({ tool_input: null, tool_name: "Edit" });
+			}).toThrowError(TypeError);
+		});
+
+		it("should throw when file_path is missing", () => {
+			expect.assertions(1);
+
+			expect(() => {
+				narrowToolInput({ tool_input: { content: "x" }, tool_name: "Write" });
+			}).toThrowError(TypeError);
+		});
+
+		it("should throw when file_path is empty", () => {
+			expect.assertions(1);
+
+			expect(() => {
+				narrowToolInput({ tool_input: { file_path: "" }, tool_name: "Edit" });
+			}).toThrowError(TypeError);
+		});
+
+		it("should throw when file_path is not a string", () => {
+			expect.assertions(1);
+
+			expect(() => {
+				narrowToolInput({ tool_input: { file_path: 123 }, tool_name: "Edit" });
+			}).toThrowError(TypeError);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Closes #15.

Adds a `narrowToolInput` helper that replaces the cast + non-null-assertion + eslint-disable triplet at three hook call sites.

## Before

```ts
// eslint-disable-next-line ts/no-non-null-assertion -- Edit/Write tool_input always has file_path
const FILE_PATH = (input.tool_input as Record<string, string>)["file_path"]!;
```

## After

```ts
const FILE_PATH = narrowToolInput(input).file_path;
```

The helper performs runtime validation (checks `tool_input` is an object, `file_path` is a non-empty string), and returns a typed shape from the SDK's `FileEditInput` / `FileWriteInput`. Throws `TypeError` on invalid shape.

## Call sites cleaned up

- `hooks/lint.ts` (PostToolUse)
- `hooks/type-check.ts` (PostToolUse)
- `hooks/lint-guard.ts` (PreToolUse)

All three eslint-disables for `ts/no-non-null-assertion` removed.

## Note on signature

Helper input is duck-typed `{ tool_name: string; tool_input: unknown }` rather than the SDK's discriminated union. TS narrowing via OR conditions on `tool_name` (`=== "Edit" || === "Write"`) doesn't carry through to function-argument assignability cleanly across the SDK union. The runtime check inside the helper validates correctness.

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (212 tests; +7 new for `narrowToolInput`)
- [x] `pnpm build` passes
- [x] Returns `file_path` for valid Edit/Write input
- [x] Throws when `tool_input` is non-object, null, missing `file_path`, empty `file_path`, or non-string `file_path`

🤖 Generated with [Claude Code](https://claude.com/claude-code)