### PR TITLE
fix(lint): GC stale subagent buckets on SessionStart

### DIFF
--- a/hooks/clear-lint-state.ts
+++ b/hooks/clear-lint-state.ts
@@ -1,10 +1,10 @@
 import type { SessionStartHookInput } from "@anthropic-ai/claude-agent-sdk";
 
 import {
-	clearEditedFiles,
+	clearAllBuckets,
 	clearLintAttempts,
+	clearStaleBuckets,
 	clearStopAttempts,
-	getBucketKey,
 } from "../scripts/lint.ts";
 import { clearTypecheckStopAttempts } from "../scripts/type-check.ts";
 import { readStdinJson } from "./io.ts";
@@ -14,4 +14,13 @@ const input = await readStdinJson<SessionStartHookInput>();
 clearLintAttempts();
 clearStopAttempts();
 clearTypecheckStopAttempts();
-clearEditedFiles(getBucketKey(input));
+
+// On `startup`, the session_id is freshly minted; nothing from any prior
+// session is valid, so wipe every bucket. On `resume`/`clear`/`compact`, the
+// session persists (subagents may still hold valid edits mid-task), so keep
+// only buckets prefixed with the current session_id and drop the rest.
+if (input.source === "startup") {
+	clearAllBuckets();
+} else {
+	clearStaleBuckets(input.session_id);
+}

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -193,6 +193,61 @@ export function clearEditedFiles(bucketKey: string): void {
 }
 
 /**
+ * Drop every bucket from the edited-files state. Used on `SessionStart` with
+ * source `startup` where `session_id` is fresh and no prior bucket is valid.
+ * Unlinks the file if it exists; otherwise no-op.
+ */
+export function clearAllBuckets(): void {
+	if (existsSync(EDITED_FILES_PATH)) {
+		unlinkSync(EDITED_FILES_PATH);
+	}
+}
+
+/**
+ * Garbage-collect buckets that do not belong to the current session. Used on
+ * `SessionStart` with source `resume`/`clear`/`compact` where the session
+ * persists but stale `<dead_session>:agent_*` entries from prior sessions may
+ * linger. Keeps every bucket whose key starts with `${currentSessionId}:` and
+ * drops the rest. Unlinks the file if the resulting state is empty.
+ *
+ * @param currentSessionId - SDK-provided `session_id` for the active session.
+ */
+export function clearStaleBuckets(currentSessionId: string): void {
+	if (!existsSync(EDITED_FILES_PATH)) {
+		return;
+	}
+
+	let state: EditedFilesState;
+	try {
+		state = JSON.parse(readFileSync(EDITED_FILES_PATH, "utf-8")) as unknown as EditedFilesState;
+	} catch {
+		unlinkSync(EDITED_FILES_PATH);
+		return;
+	}
+
+	const prefix = `${currentSessionId}:`;
+	const survivors = {} satisfies EditedFilesState as EditedFilesState;
+	let hasDropped = false;
+	for (const [key, bucket] of Object.entries(state)) {
+		if (key.startsWith(prefix)) {
+			survivors[key] = bucket;
+		} else {
+			hasDropped = true;
+		}
+	}
+
+	if (!hasDropped) {
+		return;
+	}
+
+	if (Object.keys(survivors).length === 0) {
+		unlinkSync(EDITED_FILES_PATH);
+	} else {
+		writeFileSync(EDITED_FILES_PATH, JSON.stringify(survivors));
+	}
+}
+
+/**
  * Mark a bucket as surfaced at the given timestamp (defaults to now). Used by
  * surface-gating logic to track which edits have already been reported to the
  * agent. Hooks call this after emitting a diagnostics surface so subsequent

--- a/test/lint.spec.ts
+++ b/test/lint.spec.ts
@@ -19,9 +19,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
 	buildHookOutput,
+	clearAllBuckets,
 	clearCache,
 	clearEditedFiles,
 	clearLintAttempts,
+	clearStaleBuckets,
 	clearStopAttempts,
 	DEFAULT_CACHE_BUST,
 	findEntryPoints,
@@ -2374,6 +2376,142 @@ describe(lint, () => {
 			mockedReadFileSync.mockReturnValue("{bad");
 
 			clearEditedFiles("abc123:main");
+
+			expect(mockedUnlinkSync).toHaveBeenCalledWith(".claude/state/edited-files.json");
+		});
+	});
+
+	describe(clearAllBuckets, () => {
+		it("should no-op when file missing", () => {
+			expect.assertions(1);
+
+			mockedUnlinkSync.mockClear();
+			mockedExistsSync.mockReturnValue(false);
+
+			clearAllBuckets();
+
+			expect(mockedUnlinkSync).not.toHaveBeenCalled();
+		});
+
+		it("should unlink the file when present", () => {
+			expect.assertions(1);
+
+			mockedUnlinkSync.mockClear();
+			mockedExistsSync.mockReturnValue(true);
+
+			clearAllBuckets();
+
+			expect(mockedUnlinkSync).toHaveBeenCalledWith(".claude/state/edited-files.json");
+		});
+	});
+
+	describe(clearStaleBuckets, () => {
+		it("should no-op when file missing", () => {
+			expect.assertions(2);
+
+			mockedUnlinkSync.mockClear();
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(false);
+
+			clearStaleBuckets("abc123");
+
+			expect(mockedUnlinkSync).not.toHaveBeenCalled();
+			expect(mockedWriteFileSync).not.toHaveBeenCalled();
+		});
+
+		it("should keep buckets matching current session prefix", () => {
+			expect.assertions(1);
+
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"abc123:agent_xyz": { edited: ["src/bar.ts"], lastSurfacedAt: null },
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+					"old-session:agent_old": { edited: ["src/baz.ts"], lastSurfacedAt: 42 },
+					"old-session:main": { edited: [], lastSurfacedAt: 100 },
+				}),
+			);
+
+			clearStaleBuckets("abc123");
+
+			expect(mockedWriteFileSync).toHaveBeenCalledWith(
+				".claude/state/edited-files.json",
+				JSON.stringify({
+					"abc123:agent_xyz": { edited: ["src/bar.ts"], lastSurfacedAt: null },
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
+			);
+		});
+
+		it("should unlink the file when no buckets survive the sweep", () => {
+			expect.assertions(2);
+
+			mockedUnlinkSync.mockClear();
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"old-session-1:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+					"old-session-2:agent_xyz": { edited: ["src/bar.ts"], lastSurfacedAt: null },
+				}),
+			);
+
+			clearStaleBuckets("abc123");
+
+			expect(mockedUnlinkSync).toHaveBeenCalledWith(".claude/state/edited-files.json");
+			expect(mockedWriteFileSync).not.toHaveBeenCalled();
+		});
+
+		it("should no-op when every bucket already belongs to current session", () => {
+			expect.assertions(2);
+
+			mockedUnlinkSync.mockClear();
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"abc123:agent_xyz": { edited: ["src/bar.ts"], lastSurfacedAt: null },
+					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
+			);
+
+			clearStaleBuckets("abc123");
+
+			expect(mockedUnlinkSync).not.toHaveBeenCalled();
+			expect(mockedWriteFileSync).not.toHaveBeenCalled();
+		});
+
+		it("should not match a session id that is a prefix of a longer one", () => {
+			expect.assertions(1);
+
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"abc123:main": { edited: ["src/bar.ts"], lastSurfacedAt: null },
+					"abc:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
+			);
+
+			clearStaleBuckets("abc");
+
+			expect(mockedWriteFileSync).toHaveBeenCalledWith(
+				".claude/state/edited-files.json",
+				JSON.stringify({
+					"abc:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
+			);
+		});
+
+		it("should delete file on corrupt JSON", () => {
+			expect.assertions(1);
+
+			mockedUnlinkSync.mockClear();
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue("{bad");
+
+			clearStaleBuckets("abc123");
 
 			expect(mockedUnlinkSync).toHaveBeenCalledWith(".claude/state/edited-files.json");
 		});


### PR DESCRIPTION
Closes #16.

## Summary

- `hooks/clear-lint-state.ts` previously cleared only `<current_session>:main`, leaving `<dead_session>:agent_xyz` entries in `edited-files.json` forever as `session_id` rotates between sessions.
- Adds `clearAllBuckets()` and `clearStaleBuckets(currentSessionId)` helpers in `scripts/lint.ts` next to existing state accessors.
- `clear-lint-state.ts` now branches on `input.source`:
  - `startup` -> `clearAllBuckets()` (fresh `session_id`, nothing prior is valid)
  - `resume` / `clear` / `compact` -> `clearStaleBuckets(input.session_id)` (same session, subagents may still hold valid mid-task edits, so keep only buckets prefixed with the current `session_id`)

`lint-attempts` / `stop-attempts` / `typecheck-stop` clearing is unchanged.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test --run` — 220/220 tests pass, including new coverage in `test/lint.spec.ts`:
  - `clearAllBuckets` no-ops on missing file; unlinks when present
  - `clearStaleBuckets` keeps current-session buckets, drops others, writes back the survivors
  - `clearStaleBuckets` unlinks the file when no bucket survives
  - `clearStaleBuckets` no-ops when every bucket already belongs to the current session
  - `clearStaleBuckets` does NOT match a session id that is a prefix of a longer one (uses `${id}:` boundary)
  - `clearStaleBuckets` deletes the file on corrupt JSON
- [x] `pnpm build` passes