### PR TITLE
fix(lint): guard max-lint-attempts parsing against NaN

### DIFF
--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -379,8 +379,10 @@ export function readSettings(): LintSettings {
 		: [];
 
 	const maxAttemptsRaw = fields.get("max-lint-attempts");
-	const maxLintAttempts =
-		maxAttemptsRaw !== undefined ? Number(maxAttemptsRaw) : DEFAULT_MAX_LINT_ATTEMPTS;
+	const maxAttemptsParsed = maxAttemptsRaw !== undefined ? Number(maxAttemptsRaw) : Number.NaN;
+	const maxLintAttempts = Number.isFinite(maxAttemptsParsed)
+		? maxAttemptsParsed
+		: DEFAULT_MAX_LINT_ATTEMPTS;
 
 	const maxErrorsRaw = fields.get("max-lint-errors");
 	const maxErrorsParsed = maxErrorsRaw !== undefined ? Number(maxErrorsRaw) : Number.NaN;

--- a/test/lint.spec.ts
+++ b/test/lint.spec.ts
@@ -754,6 +754,24 @@ describe(lint, () => {
 			expect(readSettings()).toMatchObject({ maxLintErrors: 10 });
 		});
 
+		it("should parse max-lint-attempts as a number", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue('---\nmax-lint-attempts: "5"\n---\n');
+
+			expect(readSettings()).toMatchObject({ maxLintAttempts: 5 });
+		});
+
+		it("should fall back to default when max-lint-attempts is non-numeric", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue('---\nmax-lint-attempts: "xyz"\n---\n');
+
+			expect(readSettings()).toMatchObject({ maxLintAttempts: 1 });
+		});
+
 		it("should parse lint-auto-fix-on-batch: false", () => {
 			expect.assertions(1);
 


### PR DESCRIPTION
## Summary

Non-numeric `max-lint-attempts` values silently coerced to `NaN` via `Number()`. The per-file loop guard (`count >= settings.maxLintAttempts`) never trips when the threshold is `NaN`, so the safety cap that prevents runaway lint loops was bypassed.

## Fix

Apply the same `Number.isFinite` guard pattern that `max-lint-errors` already uses:

```ts
const maxAttemptsParsed = maxAttemptsRaw !== undefined ? Number(maxAttemptsRaw) : Number.NaN;
const maxLintAttempts = Number.isFinite(maxAttemptsParsed)
    ? maxAttemptsParsed
    : DEFAULT_MAX_LINT_ATTEMPTS;
```

## Discovered

Surfaced by the settings-docs agent while preparing PR #20 — it noticed the asymmetry between `max-lint-errors` (correctly guarded) and `max-lint-attempts` (not guarded).

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (214 tests; +2 new)
- [x] `pnpm build` passes
- [x] Numeric `max-lint-attempts` value parsed correctly
- [x] Non-numeric value falls back to `DEFAULT_MAX_LINT_ATTEMPTS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)