### PR TITLE
fix(lint): partition lint state by session_id with dead-session GC

### DIFF
--- a/.claude/sentinel.local.md
+++ b/.claude/sentinel.local.md
@@ -1,3 +1,4 @@
 ---
 debug: true
+lint-cadence: tiered
 ---

--- a/hooks/clear-lint-state.ts
+++ b/hooks/clear-lint-state.ts
@@ -1,26 +1,16 @@
 import type { SessionStartHookInput } from "@anthropic-ai/claude-agent-sdk";
 
+import process from "node:process";
+
 import {
-	clearAllBuckets,
-	clearLintAttempts,
-	clearStaleBuckets,
-	clearStopAttempts,
+	getClaudePid,
+	loadLiveSessions,
+	pruneDeadSessions,
+	registerSession,
 } from "../scripts/lint.ts";
-import { clearTypecheckStopAttempts } from "../scripts/type-check.ts";
 import { readStdinJson } from "./io.ts";
 
 const input = await readStdinJson<SessionStartHookInput>();
-
-clearLintAttempts();
-clearStopAttempts();
-clearTypecheckStopAttempts();
-
-// On `startup`, the session_id is freshly minted; nothing from any prior
-// session is valid, so wipe every bucket. On `resume`/`clear`/`compact`, the
-// session persists (subagents may still hold valid edits mid-task), so keep
-// only buckets prefixed with the current session_id and drop the rest.
-if (input.source === "startup") {
-	clearAllBuckets();
-} else {
-	clearStaleBuckets(input.session_id);
-}
+const PID = getClaudePid() ?? String(process.ppid);
+registerSession(input.session_id, PID);
+pruneDeadSessions(loadLiveSessions());

--- a/hooks/lint-stop.ts
+++ b/hooks/lint-stop.ts
@@ -87,9 +87,9 @@ debug("restartDaemon: end");
 
 const result = stopDecision({
 	errorFiles,
-	lintAttempts: readLintAttempts(),
+	lintAttempts: readLintAttempts(input.session_id),
 	maxLintAttempts: settings.maxLintAttempts,
-	stopAttempts: readStopAttempts(),
+	stopAttempts: readStopAttempts(BUCKET_KEY),
 });
 
 debug(`stopDecision: ${JSON.stringify(result)}`);
@@ -103,11 +103,11 @@ if (result === undefined) {
 }
 
 if (result.resetStopAttempts) {
-	writeStopAttempts(0);
+	writeStopAttempts(BUCKET_KEY, 0);
 	process.exit(0);
 }
 
-writeStopAttempts(readStopAttempts() + 1);
+writeStopAttempts(BUCKET_KEY, readStopAttempts(BUCKET_KEY) + 1);
 
 if (debugLog.length > 0) {
 	result.reason = `${result.reason ?? ""}\n\n[lint-stop debug]\n${debugLog.join("\n")}`;

--- a/hooks/lint.ts
+++ b/hooks/lint.ts
@@ -3,14 +3,14 @@ import type { PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import process from "node:process";
 
 import {
+	clearLintAttempt,
 	getBucketKey,
+	incrementLintAttempt,
 	isInProject,
 	lint,
 	narrowToolInput,
-	readLintAttempts,
 	readSettings,
 	writeEditedFile,
-	writeLintAttempts,
 } from "../scripts/lint.ts";
 import { readStdinJson, writeStdoutJson } from "./io.ts";
 
@@ -29,13 +29,10 @@ if (input.tool_name !== "Write" && input.tool_name !== "Edit") {
 const FILE_PATH = narrowToolInput(input).file_path;
 
 function run(filePath: string): void {
-	const attempts = readLintAttempts();
 	const result = lint(filePath, ["--fix"], settings);
 
 	if (result !== undefined) {
-		const count = (attempts[filePath] ?? 0) + 1;
-		attempts[filePath] = count;
-		writeLintAttempts(attempts);
+		const count = incrementLintAttempt(input.session_id, filePath);
 
 		if (count >= settings.maxLintAttempts && result.hookSpecificOutput) {
 			const loopNotice = `<workspace_diagnostics source="lint-loop">\n${filePath} has surfaced lint issues ${count} times. The fix loop appears stuck — surface the remaining diagnostics to the user instead of editing further?\n</workspace_diagnostics>`;
@@ -43,9 +40,8 @@ function run(filePath: string): void {
 		}
 
 		writeStdoutJson(result);
-	} else if (filePath in attempts) {
-		delete attempts[filePath];
-		writeLintAttempts(attempts);
+	} else {
+		clearLintAttempt(input.session_id, filePath);
 	}
 }
 

--- a/hooks/type-check-stop.ts
+++ b/hooks/type-check-stop.ts
@@ -91,9 +91,9 @@ debug(`errorFiles: ${JSON.stringify(errorFiles)}`);
 
 const result = typecheckStopDecision({
 	errorFiles,
-	lintAttempts: readLintAttempts(),
+	lintAttempts: readLintAttempts(input.session_id),
 	maxLintAttempts: settings.maxLintAttempts,
-	stopAttempts: readTypecheckStopAttempts(),
+	stopAttempts: readTypecheckStopAttempts(BUCKET_KEY),
 });
 
 debug(`stopDecision: ${JSON.stringify(result)}`);
@@ -107,11 +107,11 @@ if (result === undefined) {
 }
 
 if (result.resetStopAttempts) {
-	writeTypecheckStopAttempts(0);
+	writeTypecheckStopAttempts(BUCKET_KEY, 0);
 	process.exit(0);
 }
 
-writeTypecheckStopAttempts(readTypecheckStopAttempts() + 1);
+writeTypecheckStopAttempts(BUCKET_KEY, readTypecheckStopAttempts(BUCKET_KEY) + 1);
 
 if (debugLog.length > 0) {
 	result.reason = `${result.reason ?? ""}\n\n[type-check-stop debug]\n${debugLog.join("\n")}`;

--- a/hooks/type-check.ts
+++ b/hooks/type-check.ts
@@ -3,13 +3,13 @@ import type { PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import process from "node:process";
 
 import {
+	clearLintAttempt,
 	getBucketKey,
+	incrementLintAttempt,
 	isInProject,
 	narrowToolInput,
-	readLintAttempts,
 	readSettings,
 	writeEditedFile,
-	writeLintAttempts,
 } from "../scripts/lint.ts";
 import { typeCheck } from "../scripts/type-check.ts";
 import { readStdinJson, writeStdoutJson } from "./io.ts";
@@ -29,22 +29,18 @@ if (input.tool_name !== "Write" && input.tool_name !== "Edit") {
 const FILE_PATH = narrowToolInput(input).file_path;
 
 function run(filePath: string): void {
-	const attempts = readLintAttempts();
 	const result = typeCheck(filePath, settings);
 
 	if (result !== undefined) {
-		const count = (attempts[filePath] ?? 0) + 1;
-		attempts[filePath] = count;
-		writeLintAttempts(attempts);
+		const count = incrementLintAttempt(input.session_id, filePath);
 
 		if (count >= settings.maxLintAttempts && result.hookSpecificOutput) {
 			result.hookSpecificOutput.additionalContext = `CRITICAL: ${filePath} failed type-check ${count} times. If you're stuck in a loop, STOP editing this file and report type errors to user for assistance.\n${result.hookSpecificOutput.additionalContext}`;
 		}
 
 		writeStdoutJson(result);
-	} else if (filePath in attempts) {
-		delete attempts[filePath];
-		writeLintAttempts(attempts);
+	} else {
+		clearLintAttempt(input.session_id, filePath);
 	}
 }
 

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -11,6 +11,7 @@ import {
 	existsSync,
 	globSync,
 	mkdirSync,
+	readdirSync,
 	readFileSync,
 	statSync,
 	unlinkSync,
@@ -85,7 +86,9 @@ export function isProtectedFile(filename: string): boolean {
 
 const LINT_STATE_PATH = ".claude/state/lint-attempts.json";
 const STOP_STATE_PATH = ".claude/state/stop-attempts.json";
+const TYPECHECK_STOP_STATE_PATH = ".claude/state/typecheck-stop-attempts.json";
 const EDITED_FILES_PATH = ".claude/state/edited-files.json";
+const SESSIONS_DIR = ".claude/state/sessions";
 const RESTART_DAEMON_LOG = ".claude/state/restartDaemon.log";
 
 const IS_RESTART_DAEMON_DEBUG = false as boolean;
@@ -193,58 +196,71 @@ export function clearEditedFiles(bucketKey: string): void {
 }
 
 /**
- * Drop every bucket from the edited-files state. Used on `SessionStart` with
- * source `startup` where `session_id` is fresh and no prior bucket is valid.
- * Unlinks the file if it exists; otherwise no-op.
+ * Register the active session with the live-session registry. Writes the claude
+ * PID into `.claude/state/sessions/<sessionId>` so concurrent chats — and the
+ * `pruneDeadSessions` sweep at `SessionStart` — can tell a live session from a
+ * crashed one. Idempotent: overwrites the lockfile each call to refresh the PID
+ * across `resume`/`clear`/`compact`.
+ *
+ * @param sessionId - SDK-provided `session_id`.
+ * @param pid - PID string to record (typically from {@link getClaudePid}).
  */
-export function clearAllBuckets(): void {
-	if (existsSync(EDITED_FILES_PATH)) {
-		unlinkSync(EDITED_FILES_PATH);
-	}
+export function registerSession(sessionId: string, pid: string): void {
+	mkdirSync(SESSIONS_DIR, { recursive: true });
+	writeFileSync(join(SESSIONS_DIR, sessionId), pid);
 }
 
 /**
- * Garbage-collect buckets that do not belong to the current session. Used on
- * `SessionStart` with source `resume`/`clear`/`compact` where the session
- * persists but stale `<dead_session>:agent_*` entries from prior sessions may
- * linger. Keeps every bucket whose key starts with `${currentSessionId}:` and
- * drops the rest. Unlinks the file if the resulting state is empty.
+ * Walk the session registry and return the set of session IDs whose recorded
+ * PID still has a live process. Entries whose PID is dead (or whose contents
+ * are malformed) are unlinked as a side effect — the registry self-cleans.
  *
- * @param currentSessionId - SDK-provided `session_id` for the active session.
+ * @returns Set of session IDs whose owning claude process is still alive.
  */
-export function clearStaleBuckets(currentSessionId: string): void {
-	if (!existsSync(EDITED_FILES_PATH)) {
-		return;
+export function loadLiveSessions(): Set<string> {
+	const live = new Set<string>();
+	if (!existsSync(SESSIONS_DIR)) {
+		return live;
 	}
 
-	let state: EditedFilesState;
-	try {
-		state = JSON.parse(readFileSync(EDITED_FILES_PATH, "utf-8")) as unknown as EditedFilesState;
-	} catch {
-		unlinkSync(EDITED_FILES_PATH);
-		return;
-	}
+	for (const entry of readdirSync(SESSIONS_DIR)) {
+		const lockfile = join(SESSIONS_DIR, entry);
+		const pid = Number(readFileSync(lockfile, "utf-8").trim());
+		if (Number.isFinite(pid)) {
+			try {
+				process.kill(pid, 0);
+				live.add(entry);
+				continue;
+			} catch {
+				// dead pid → fall through to unlink
+			}
+		}
 
-	const prefix = `${currentSessionId}:`;
-	const survivors = {} satisfies EditedFilesState as EditedFilesState;
-	let hasDropped = false;
-	for (const [key, bucket] of Object.entries(state)) {
-		if (key.startsWith(prefix)) {
-			survivors[key] = bucket;
-		} else {
-			hasDropped = true;
+		try {
+			unlinkSync(lockfile);
+		} catch {
+			// best-effort
 		}
 	}
 
-	if (!hasDropped) {
-		return;
-	}
+	return live;
+}
 
-	if (Object.keys(survivors).length === 0) {
-		unlinkSync(EDITED_FILES_PATH);
-	} else {
-		writeFileSync(EDITED_FILES_PATH, JSON.stringify(survivors));
-	}
+/**
+ * Drop every per-session entry whose owning session is no longer in the
+ * registry. Sweeps all four state files: `lint-attempts.json` (sessionId
+ * keys), `stop-attempts.json` and `typecheck-stop-attempts.json` (bucketKey
+ * keys), and `edited-files.json` (bucketKey keys). For bucketKey-shaped files
+ * the prefix before the first `:` is the sessionId. Unlinks any file whose
+ * surviving map is empty.
+ *
+ * @param liveSessions - Set returned by {@link loadLiveSessions}.
+ */
+export function pruneDeadSessions(liveSessions: Set<string>): void {
+	pruneStateBySessionId(LINT_STATE_PATH, liveSessions);
+	pruneStateByBucketKey(STOP_STATE_PATH, liveSessions);
+	pruneStateByBucketKey(TYPECHECK_STOP_STATE_PATH, liveSessions);
+	pruneStateByBucketKey(EDITED_FILES_PATH, liveSessions);
 }
 
 /**
@@ -316,19 +332,7 @@ export function getTransitiveDependents(
 		.map((file) => join(sourceRoot, file));
 }
 
-function readState(): EditedFilesState {
-	if (!existsSync(EDITED_FILES_PATH)) {
-		return {};
-	}
-
-	try {
-		return JSON.parse(readFileSync(EDITED_FILES_PATH, "utf-8")) as unknown as EditedFilesState;
-	} catch {
-		return {};
-	}
-}
-
-function getClaudePid(): string | undefined {
+export function getClaudePid(): string | undefined {
 	const ssePort = process.env["CLAUDE_CODE_SSE_PORT"] ?? "";
 	const cacheFile = ssePort.length > 0 ? `${CLAUDE_PID_PATH}-${ssePort}` : CLAUDE_PID_PATH;
 
@@ -369,6 +373,69 @@ while ($currentPid -and $currentPid -ne 0) {
 	}
 
 	return undefined;
+}
+
+function readState(): EditedFilesState {
+	if (!existsSync(EDITED_FILES_PATH)) {
+		return {};
+	}
+
+	try {
+		return JSON.parse(readFileSync(EDITED_FILES_PATH, "utf-8")) as unknown as EditedFilesState;
+	} catch {
+		return {};
+	}
+}
+
+function pruneStateFile(path: string, keepKey: (key: string) => boolean): void {
+	if (!existsSync(path)) {
+		return;
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(readFileSync(path, "utf-8"));
+	} catch {
+		unlinkSync(path);
+		return;
+	}
+
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		unlinkSync(path);
+		return;
+	}
+
+	const state = parsed as Record<string, unknown>;
+	const survivors = {} satisfies Record<string, unknown> as Record<string, unknown>;
+	let hasDropped = false;
+	for (const [key, value] of Object.entries(state)) {
+		if (keepKey(key)) {
+			survivors[key] = value;
+		} else {
+			hasDropped = true;
+		}
+	}
+
+	if (!hasDropped) {
+		return;
+	}
+
+	if (Object.keys(survivors).length === 0) {
+		unlinkSync(path);
+	} else {
+		writeFileSync(path, JSON.stringify(survivors));
+	}
+}
+
+function pruneStateBySessionId(path: string, liveSessions: Set<string>): void {
+	pruneStateFile(path, (key) => liveSessions.has(key));
+}
+
+function pruneStateByBucketKey(path: string, liveSessions: Set<string>): void {
+	pruneStateFile(path, (key) => {
+		const sessionId = key.split(":", 1)[0] ?? key;
+		return liveSessions.has(sessionId);
+	});
 }
 
 const ESLINT_CACHE_PATH = ".eslintcache";
@@ -416,6 +483,10 @@ interface StopDecisionInput {
 	maxLintAttempts: number;
 	stopAttempts: number;
 }
+
+type LintAttemptsState = Record<string, Record<string, number>>;
+
+type StopAttemptsState = Record<string, number>;
 
 export function readSettings(): LintSettings {
 	if (!existsSync(SETTINGS_FILE)) {
@@ -535,7 +606,6 @@ export function invertGraph(graph: DependencyGraph, target: string): Array<strin
 
 	return importers;
 }
-
 export function findSourceRoot(filePath: string): string | undefined {
 	let current = dirname(filePath);
 	while (current !== dirname(current)) {
@@ -554,38 +624,56 @@ export function findSourceRoot(filePath: string): string | undefined {
 	return undefined;
 }
 
-export function readLintAttempts(): Record<string, number> {
-	if (!existsSync(LINT_STATE_PATH)) {
-		return {};
+export function readLintAttempts(sessionId: string): Record<string, number> {
+	const state = readLintAttemptsState();
+	return state[sessionId] ?? {};
+}
+
+export function writeLintAttempts(sessionId: string, attempts: Record<string, number>): void {
+	const state = readLintAttemptsState();
+	state[sessionId] = attempts;
+	writeLintAttemptsState(state);
+}
+
+export function incrementLintAttempt(sessionId: string, filePath: string): number {
+	const state = readLintAttemptsState();
+	const attempts = state[sessionId] ?? {};
+	const count = (attempts[filePath] ?? 0) + 1;
+	attempts[filePath] = count;
+	state[sessionId] = attempts;
+	writeLintAttemptsState(state);
+	return count;
+}
+
+export function clearLintAttempt(sessionId: string, filePath: string): void {
+	const state = readLintAttemptsState();
+	const attempts = state[sessionId];
+	if (attempts === undefined || !(filePath in attempts)) {
+		return;
 	}
 
-	try {
-		return JSON.parse(readFileSync(LINT_STATE_PATH, "utf-8")) as Record<string, number>;
-	} catch {
-		return {};
+	delete attempts[filePath];
+	if (Object.keys(attempts).length === 0) {
+		delete state[sessionId];
+	} else {
+		state[sessionId] = attempts;
+	}
+
+	if (Object.keys(state).length === 0) {
+		unlinkSync(LINT_STATE_PATH);
+	} else {
+		writeLintAttemptsState(state);
 	}
 }
 
-export function writeLintAttempts(attempts: Record<string, number>): void {
-	mkdirSync(dirname(LINT_STATE_PATH), { recursive: true });
-	writeFileSync(LINT_STATE_PATH, JSON.stringify(attempts));
+export function readStopAttempts(bucketKey: string): number {
+	return readStopAttemptsState(STOP_STATE_PATH)[bucketKey] ?? 0;
 }
 
-export function readStopAttempts(): number {
-	if (!existsSync(STOP_STATE_PATH)) {
-		return 0;
-	}
-
-	try {
-		return JSON.parse(readFileSync(STOP_STATE_PATH, "utf-8")) as number;
-	} catch {
-		return 0;
-	}
-}
-
-export function writeStopAttempts(count: number): void {
-	mkdirSync(dirname(STOP_STATE_PATH), { recursive: true });
-	writeFileSync(STOP_STATE_PATH, JSON.stringify(count));
+export function writeStopAttempts(bucketKey: string, count: number): void {
+	const state = readStopAttemptsState(STOP_STATE_PATH);
+	state[bucketKey] = count;
+	writeStopAttemptsState(STOP_STATE_PATH, state);
 }
 
 export function stopDecision(input: StopDecisionInput): StopDecisionResult | undefined {
@@ -616,18 +704,6 @@ export function stopDecision(input: StopDecisionInput): StopDecisionResult | und
 		decision: "block",
 		reason: `<workspace_diagnostics source="eslint">\nLint issues remain in: ${fileList}. If related to recent changes, address before continuing?\n</workspace_diagnostics>`,
 	};
-}
-
-export function clearStopAttempts(): void {
-	if (existsSync(STOP_STATE_PATH)) {
-		unlinkSync(STOP_STATE_PATH);
-	}
-}
-
-export function clearLintAttempts(): void {
-	if (existsSync(LINT_STATE_PATH)) {
-		unlinkSync(LINT_STATE_PATH);
-	}
 }
 
 export function resolveBustFiles(patterns: Array<string>): Array<string> {
@@ -816,6 +892,40 @@ setTimeout(() => {
 		const message = err instanceof Error ? err.message : String(err);
 		process.stderr.write(`[eslint_d restart] ${message}\n`);
 	}
+}
+
+function readLintAttemptsState(): LintAttemptsState {
+	if (!existsSync(LINT_STATE_PATH)) {
+		return {};
+	}
+
+	try {
+		return JSON.parse(readFileSync(LINT_STATE_PATH, "utf-8")) as LintAttemptsState;
+	} catch {
+		return {};
+	}
+}
+
+function writeLintAttemptsState(state: LintAttemptsState): void {
+	mkdirSync(dirname(LINT_STATE_PATH), { recursive: true });
+	writeFileSync(LINT_STATE_PATH, JSON.stringify(state));
+}
+
+function readStopAttemptsState(path: string): StopAttemptsState {
+	if (!existsSync(path)) {
+		return {};
+	}
+
+	try {
+		return JSON.parse(readFileSync(path, "utf-8")) as StopAttemptsState;
+	} catch {
+		return {};
+	}
+}
+
+function writeStopAttemptsState(path: string, state: StopAttemptsState): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, JSON.stringify(state));
 }
 
 const RULE_TOKEN_PATTERN = /([\w-]+\/[\w-]+|[\w-]+)$/;

--- a/scripts/type-check.ts
+++ b/scripts/type-check.ts
@@ -7,7 +7,7 @@ import { createFilesMatcher, parseTsconfig } from "get-tsconfig";
 import type { Buffer } from "node:buffer";
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 
 type PostToolUseHookOutput = SyncHookJSONOutput & {
@@ -179,6 +179,8 @@ interface TypecheckStopDecisionInput {
 	stopAttempts: number;
 }
 
+type StopAttemptsState = Record<string, number>;
+
 export function partitionErrors(
 	errors: Array<string>,
 	filePath: string,
@@ -300,25 +302,25 @@ export function typecheckStopDecision(
 	};
 }
 
-export function readTypecheckStopAttempts(): number {
+export function readTypecheckStopAttempts(bucketKey: string): number {
+	return readStopAttemptsState()[bucketKey] ?? 0;
+}
+
+export function writeTypecheckStopAttempts(bucketKey: string, count: number): void {
+	const state = readStopAttemptsState();
+	state[bucketKey] = count;
+	mkdirSync(dirname(STOP_STATE_PATH), { recursive: true });
+	writeFileSync(STOP_STATE_PATH, JSON.stringify(state));
+}
+
+function readStopAttemptsState(): StopAttemptsState {
 	if (!existsSync(STOP_STATE_PATH)) {
-		return 0;
+		return {};
 	}
 
 	try {
-		return JSON.parse(readFileSync(STOP_STATE_PATH, "utf-8")) as number;
+		return JSON.parse(readFileSync(STOP_STATE_PATH, "utf-8")) as StopAttemptsState;
 	} catch {
-		return 0;
-	}
-}
-
-export function writeTypecheckStopAttempts(count: number): void {
-	mkdirSync(dirname(STOP_STATE_PATH), { recursive: true });
-	writeFileSync(STOP_STATE_PATH, JSON.stringify(count));
-}
-
-export function clearTypecheckStopAttempts(): void {
-	if (existsSync(STOP_STATE_PATH)) {
-		unlinkSync(STOP_STATE_PATH);
+		return {};
 	}
 }

--- a/test/lint.spec.ts
+++ b/test/lint.spec.ts
@@ -7,6 +7,7 @@ import {
 	existsSync,
 	globSync,
 	mkdirSync,
+	readdirSync,
 	readFileSync,
 	statSync,
 	unlinkSync,
@@ -19,12 +20,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
 	buildHookOutput,
-	clearAllBuckets,
 	clearCache,
 	clearEditedFiles,
-	clearLintAttempts,
-	clearStaleBuckets,
-	clearStopAttempts,
+	clearLintAttempt,
 	DEFAULT_CACHE_BUST,
 	findEntryPoints,
 	findSourceRoot,
@@ -34,19 +32,23 @@ import {
 	getDependencyGraph,
 	getLastSurfacedAt,
 	getTransitiveDependents,
+	incrementLintAttempt,
 	invalidateCacheEntries,
 	invertGraph,
 	isInProject,
 	isLintableFile,
 	isProtectedFile,
 	lint,
+	loadLiveSessions,
 	main,
 	markBucketSurfaced,
 	narrowToolInput,
+	pruneDeadSessions,
 	readEditedFiles,
 	readLintAttempts,
 	readSettings,
 	readStopAttempts,
+	registerSession,
 	resolveBustFiles,
 	restartDaemon,
 	runEslint,
@@ -76,6 +78,7 @@ vi.mock(import("node:fs"), async () => {
 		existsSync: vi.fn<typeof existsSync>(() => false),
 		globSync: vi.fn<typeof globSync>(() => []),
 		mkdirSync: vi.fn<typeof mkdirSync>(),
+		readdirSync: vi.fn<(path: string) => Array<string>>(() => []),
 		readFileSync: vi.fn<typeof readFileSync>(),
 		statSync: vi.fn<typeof statSync>(),
 		unlinkSync: vi.fn<typeof unlinkSync>(),
@@ -1710,16 +1713,30 @@ describe(lint, () => {
 
 			mockedExistsSync.mockReturnValue(false);
 
-			expect(readLintAttempts()).toStrictEqual({});
+			expect(readLintAttempts("abc123")).toStrictEqual({});
 		});
 
-		it("should parse valid JSON", () => {
+		it("should return inner per-file map for the given session", () => {
 			expect.assertions(1);
 
 			mockedExistsSync.mockReturnValue(true);
-			mockedReadFileSync.mockReturnValue('{"src/foo.ts":2}');
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"abc123": { "src/foo.ts": 2 },
+					"other-session": { "src/bar.ts": 1 },
+				}),
+			);
 
-			expect(readLintAttempts()).toStrictEqual({ "src/foo.ts": 2 });
+			expect(readLintAttempts("abc123")).toStrictEqual({ "src/foo.ts": 2 });
+		});
+
+		it("should return empty object for unknown session", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(JSON.stringify({ abc123: { "src/foo.ts": 2 } }));
+
+			expect(readLintAttempts("zzz")).toStrictEqual({});
 		});
 
 		it("should return empty object on corrupt JSON", () => {
@@ -1728,48 +1745,174 @@ describe(lint, () => {
 			mockedExistsSync.mockReturnValue(true);
 			mockedReadFileSync.mockReturnValue("{bad json");
 
-			expect(readLintAttempts()).toStrictEqual({});
+			expect(readLintAttempts("abc123")).toStrictEqual({});
 		});
 	});
 
 	describe(writeLintAttempts, () => {
-		it("should create dir and write JSON", () => {
+		it("should create dir and write per-session JSON when file missing", () => {
 			expect.assertions(2);
 
 			mockedMkdirSync.mockClear();
 			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(false);
 
-			writeLintAttempts({ "src/foo.ts": 2 });
+			writeLintAttempts("abc123", { "src/foo.ts": 2 });
 
 			expect(mockedMkdirSync).toHaveBeenCalledWith(".claude/state", { recursive: true });
 			expect(mockedWriteFileSync).toHaveBeenCalledWith(
 				".claude/state/lint-attempts.json",
-				'{"src/foo.ts":2}',
+				JSON.stringify({ abc123: { "src/foo.ts": 2 } }),
 			);
+		});
+
+		it("should preserve sibling sessions when writing", () => {
+			expect.assertions(2);
+
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({ "other-session": { "src/bar.ts": 1 } }),
+			);
+
+			writeLintAttempts("abc123", { "src/foo.ts": 2 });
+
+			const lastCall = mockedWriteFileSync.mock.lastCall!;
+
+			expect(lastCall[0]).toBe(".claude/state/lint-attempts.json");
+			expect(JSON.parse(lastCall[1] as string)).toStrictEqual({
+				"abc123": { "src/foo.ts": 2 },
+				"other-session": { "src/bar.ts": 1 },
+			});
 		});
 	});
 
-	describe(clearLintAttempts, () => {
-		it("should delete file when exists", () => {
-			expect.assertions(1);
+	describe(incrementLintAttempt, () => {
+		it("should start at 1 when session and file are new", () => {
+			expect.assertions(2);
 
-			mockedUnlinkSync.mockClear();
-			mockedExistsSync.mockReturnValue(true);
-
-			clearLintAttempts();
-
-			expect(mockedUnlinkSync).toHaveBeenCalledWith(".claude/state/lint-attempts.json");
-		});
-
-		it("should no-op when file missing", () => {
-			expect.assertions(1);
-
-			mockedUnlinkSync.mockClear();
+			mockedWriteFileSync.mockClear();
 			mockedExistsSync.mockReturnValue(false);
 
-			clearLintAttempts();
+			expect(incrementLintAttempt("abc123", "src/foo.ts")).toBe(1);
+			expect(mockedWriteFileSync).toHaveBeenCalledWith(
+				".claude/state/lint-attempts.json",
+				JSON.stringify({ abc123: { "src/foo.ts": 1 } }),
+			);
+		});
+
+		it("should increment existing count for the file", () => {
+			expect.assertions(2);
+
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(JSON.stringify({ abc123: { "src/foo.ts": 2 } }));
+
+			expect(incrementLintAttempt("abc123", "src/foo.ts")).toBe(3);
+			expect(mockedWriteFileSync).toHaveBeenCalledWith(
+				".claude/state/lint-attempts.json",
+				JSON.stringify({ abc123: { "src/foo.ts": 3 } }),
+			);
+		});
+
+		it("should not affect other sessions", () => {
+			expect.assertions(2);
+
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({ "other-session": { "src/bar.ts": 5 } }),
+			);
+
+			incrementLintAttempt("abc123", "src/foo.ts");
+
+			const lastCall = mockedWriteFileSync.mock.lastCall!;
+
+			expect(lastCall[0]).toBe(".claude/state/lint-attempts.json");
+			expect(JSON.parse(lastCall[1] as string)).toStrictEqual({
+				"abc123": { "src/foo.ts": 1 },
+				"other-session": { "src/bar.ts": 5 },
+			});
+		});
+	});
+
+	describe(clearLintAttempt, () => {
+		it("should no-op when file missing", () => {
+			expect.assertions(2);
+
+			mockedUnlinkSync.mockClear();
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(false);
+
+			clearLintAttempt("abc123", "src/foo.ts");
 
 			expect(mockedUnlinkSync).not.toHaveBeenCalled();
+			expect(mockedWriteFileSync).not.toHaveBeenCalled();
+		});
+
+		it("should no-op when entry is absent", () => {
+			expect.assertions(2);
+
+			mockedUnlinkSync.mockClear();
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(JSON.stringify({ abc123: { "src/bar.ts": 1 } }));
+
+			clearLintAttempt("abc123", "src/foo.ts");
+
+			expect(mockedUnlinkSync).not.toHaveBeenCalled();
+			expect(mockedWriteFileSync).not.toHaveBeenCalled();
+		});
+
+		it("should drop just the file from the session map", () => {
+			expect.assertions(1);
+
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({ abc123: { "src/bar.ts": 1, "src/foo.ts": 2 } }),
+			);
+
+			clearLintAttempt("abc123", "src/foo.ts");
+
+			expect(mockedWriteFileSync).toHaveBeenCalledWith(
+				".claude/state/lint-attempts.json",
+				JSON.stringify({ abc123: { "src/bar.ts": 1 } }),
+			);
+		});
+
+		it("should drop the session when its inner map empties", () => {
+			expect.assertions(1);
+
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"abc123": { "src/foo.ts": 2 },
+					"other-session": { "src/bar.ts": 1 },
+				}),
+			);
+
+			clearLintAttempt("abc123", "src/foo.ts");
+
+			expect(mockedWriteFileSync).toHaveBeenCalledWith(
+				".claude/state/lint-attempts.json",
+				JSON.stringify({ "other-session": { "src/bar.ts": 1 } }),
+			);
+		});
+
+		it("should unlink the file when no sessions survive", () => {
+			expect.assertions(2);
+
+			mockedUnlinkSync.mockClear();
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(JSON.stringify({ abc123: { "src/foo.ts": 2 } }));
+
+			clearLintAttempt("abc123", "src/foo.ts");
+
+			expect(mockedUnlinkSync).toHaveBeenCalledWith(".claude/state/lint-attempts.json");
+			expect(mockedWriteFileSync).not.toHaveBeenCalled();
 		});
 	});
 
@@ -1779,16 +1922,27 @@ describe(lint, () => {
 
 			mockedExistsSync.mockReturnValue(false);
 
-			expect(readStopAttempts()).toBe(0);
+			expect(readStopAttempts("abc123:main")).toBe(0);
 		});
 
-		it("should parse valid JSON count", () => {
+		it("should return per-bucket count", () => {
 			expect.assertions(1);
 
 			mockedExistsSync.mockReturnValue(true);
-			mockedReadFileSync.mockReturnValue("2");
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({ "abc123:agent_xyz": 5, "abc123:main": 2 }),
+			);
 
-			expect(readStopAttempts()).toBe(2);
+			expect(readStopAttempts("abc123:main")).toBe(2);
+		});
+
+		it("should return 0 for unknown bucket", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(JSON.stringify({ "abc123:main": 2 }));
+
+			expect(readStopAttempts("zzz:main")).toBe(0);
 		});
 
 		it("should return 0 on corrupt JSON", () => {
@@ -1797,48 +1951,40 @@ describe(lint, () => {
 			mockedExistsSync.mockReturnValue(true);
 			mockedReadFileSync.mockReturnValue("{bad");
 
-			expect(readStopAttempts()).toBe(0);
+			expect(readStopAttempts("abc123:main")).toBe(0);
 		});
 	});
 
 	describe(writeStopAttempts, () => {
-		it("should create dir and write count", () => {
+		it("should create dir and write per-bucket count when file missing", () => {
 			expect.assertions(2);
 
 			mockedMkdirSync.mockClear();
 			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockReturnValue(false);
 
-			writeStopAttempts(2);
+			writeStopAttempts("abc123:main", 2);
 
 			expect(mockedMkdirSync).toHaveBeenCalledWith(".claude/state", { recursive: true });
 			expect(mockedWriteFileSync).toHaveBeenCalledWith(
 				".claude/state/stop-attempts.json",
-				"2",
+				JSON.stringify({ "abc123:main": 2 }),
 			);
 		});
-	});
 
-	describe(clearStopAttempts, () => {
-		it("should delete file when exists", () => {
+		it("should preserve sibling buckets when writing", () => {
 			expect.assertions(1);
 
-			mockedUnlinkSync.mockClear();
+			mockedWriteFileSync.mockClear();
 			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(JSON.stringify({ "abc123:agent_xyz": 5 }));
 
-			clearStopAttempts();
+			writeStopAttempts("abc123:main", 2);
 
-			expect(mockedUnlinkSync).toHaveBeenCalledWith(".claude/state/stop-attempts.json");
-		});
-
-		it("should no-op when file missing", () => {
-			expect.assertions(1);
-
-			mockedUnlinkSync.mockClear();
-			mockedExistsSync.mockReturnValue(false);
-
-			clearStopAttempts();
-
-			expect(mockedUnlinkSync).not.toHaveBeenCalled();
+			expect(mockedWriteFileSync).toHaveBeenCalledWith(
+				".claude/state/stop-attempts.json",
+				JSON.stringify({ "abc123:agent_xyz": 5, "abc123:main": 2 }),
+			);
 		});
 	});
 
@@ -2399,112 +2545,225 @@ describe(lint, () => {
 		});
 	});
 
-	describe(clearAllBuckets, () => {
-		it("should no-op when file missing", () => {
-			expect.assertions(1);
+	describe(registerSession, () => {
+		it("should write the pid into the sessions directory", () => {
+			expect.assertions(2);
 
-			mockedUnlinkSync.mockClear();
-			mockedExistsSync.mockReturnValue(false);
+			mockedMkdirSync.mockClear();
+			mockedWriteFileSync.mockClear();
 
-			clearAllBuckets();
+			registerSession("abc123", "12345");
 
-			expect(mockedUnlinkSync).not.toHaveBeenCalled();
-		});
-
-		it("should unlink the file when present", () => {
-			expect.assertions(1);
-
-			mockedUnlinkSync.mockClear();
-			mockedExistsSync.mockReturnValue(true);
-
-			clearAllBuckets();
-
-			expect(mockedUnlinkSync).toHaveBeenCalledWith(".claude/state/edited-files.json");
+			expect(mockedMkdirSync).toHaveBeenCalledWith(".claude/state/sessions", {
+				recursive: true,
+			});
+			expect(mockedWriteFileSync).toHaveBeenCalledWith(
+				join(".claude/state/sessions", "abc123"),
+				"12345",
+			);
 		});
 	});
 
-	describe(clearStaleBuckets, () => {
-		it("should no-op when file missing", () => {
-			expect.assertions(2);
+	describe(loadLiveSessions, () => {
+		it("should return empty set when sessions directory missing", () => {
+			expect.assertions(1);
 
-			mockedUnlinkSync.mockClear();
-			mockedWriteFileSync.mockClear();
 			mockedExistsSync.mockReturnValue(false);
 
-			clearStaleBuckets("abc123");
-
-			expect(mockedUnlinkSync).not.toHaveBeenCalled();
-			expect(mockedWriteFileSync).not.toHaveBeenCalled();
+			expect(loadLiveSessions()).toStrictEqual(new Set());
 		});
 
-		it("should keep buckets matching current session prefix", () => {
+		it("should include sessions whose pid is alive", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			vi.mocked(readdirSync).mockReturnValue(["abc123", "def456"] as never);
+			mockedReadFileSync.mockImplementation((path) => {
+				return path === join(".claude/state/sessions", "abc123") ? "111" : "222";
+			});
+			const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+
+			try {
+				expect(loadLiveSessions()).toStrictEqual(new Set(["abc123", "def456"]));
+			} finally {
+				killSpy.mockRestore();
+			}
+		});
+
+		it("should drop and unlink sessions whose pid is dead", () => {
+			expect.assertions(2);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedUnlinkSync.mockClear();
+			vi.mocked(readdirSync).mockReturnValue(["abc123", "dead-session"] as never);
+			mockedReadFileSync.mockImplementation((path) => {
+				return path === join(".claude/state/sessions", "abc123") ? "111" : "999";
+			});
+			const killSpy = vi.spyOn(process, "kill").mockImplementation((pid) => {
+				if (pid === 999) {
+					throw new Error("ESRCH");
+				}
+
+				return true;
+			});
+
+			try {
+				const live = loadLiveSessions();
+
+				expect(live).toStrictEqual(new Set(["abc123"]));
+				expect(mockedUnlinkSync).toHaveBeenCalledWith(
+					join(".claude/state/sessions", "dead-session"),
+				);
+			} finally {
+				killSpy.mockRestore();
+			}
+		});
+
+		it("should drop entries whose contents are not numeric", () => {
+			expect.assertions(2);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedUnlinkSync.mockClear();
+			vi.mocked(readdirSync).mockReturnValue(["malformed"] as never);
+			mockedReadFileSync.mockReturnValue("not-a-pid");
+
+			const live = loadLiveSessions();
+
+			expect(live).toStrictEqual(new Set());
+			expect(mockedUnlinkSync).toHaveBeenCalledWith(
+				join(".claude/state/sessions", "malformed"),
+			);
+		});
+	});
+
+	describe(pruneDeadSessions, () => {
+		it("should drop dead sessions from lint-attempts (sessionId-keyed)", () => {
 			expect.assertions(1);
 
 			mockedWriteFileSync.mockClear();
-			mockedExistsSync.mockReturnValue(true);
+			mockedExistsSync.mockImplementation(
+				(path) => path === ".claude/state/lint-attempts.json",
+			);
 			mockedReadFileSync.mockReturnValue(
 				JSON.stringify({
-					"abc123:agent_xyz": { edited: ["src/bar.ts"], lastSurfacedAt: null },
-					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
-					"old-session:agent_old": { edited: ["src/baz.ts"], lastSurfacedAt: 42 },
-					"old-session:main": { edited: [], lastSurfacedAt: 100 },
+					"dead-session": { "src/baz.ts": 1 },
+					"live123": { "src/foo.ts": 2 },
 				}),
 			);
 
-			clearStaleBuckets("abc123");
+			pruneDeadSessions(new Set(["live123"]));
+
+			expect(mockedWriteFileSync).toHaveBeenCalledWith(
+				".claude/state/lint-attempts.json",
+				JSON.stringify({ live123: { "src/foo.ts": 2 } }),
+			);
+		});
+
+		it("should drop dead sessions from stop-attempts (bucketKey-keyed)", () => {
+			expect.assertions(1);
+
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockImplementation(
+				(path) => path === ".claude/state/stop-attempts.json",
+			);
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"dead-session:main": 5,
+					"live123:agent_xyz": 1,
+					"live123:main": 2,
+				}),
+			);
+
+			pruneDeadSessions(new Set(["live123"]));
+
+			expect(mockedWriteFileSync).toHaveBeenCalledWith(
+				".claude/state/stop-attempts.json",
+				JSON.stringify({ "live123:agent_xyz": 1, "live123:main": 2 }),
+			);
+		});
+
+		it("should drop dead sessions from edited-files (bucketKey-keyed)", () => {
+			expect.assertions(1);
+
+			mockedWriteFileSync.mockClear();
+			mockedExistsSync.mockImplementation(
+				(path) => path === ".claude/state/edited-files.json",
+			);
+			mockedReadFileSync.mockReturnValue(
+				JSON.stringify({
+					"dead-session:main": { edited: ["src/baz.ts"], lastSurfacedAt: null },
+					"live123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+				}),
+			);
+
+			pruneDeadSessions(new Set(["live123"]));
 
 			expect(mockedWriteFileSync).toHaveBeenCalledWith(
 				".claude/state/edited-files.json",
 				JSON.stringify({
-					"abc123:agent_xyz": { edited: ["src/bar.ts"], lastSurfacedAt: null },
-					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+					"live123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
 				}),
 			);
 		});
 
-		it("should unlink the file when no buckets survive the sweep", () => {
-			expect.assertions(2);
+		it("should unlink files when no entries survive", () => {
+			expect.assertions(1);
 
 			mockedUnlinkSync.mockClear();
-			mockedWriteFileSync.mockClear();
-			mockedExistsSync.mockReturnValue(true);
+			mockedExistsSync.mockImplementation(
+				(path) => path === ".claude/state/lint-attempts.json",
+			);
 			mockedReadFileSync.mockReturnValue(
-				JSON.stringify({
-					"old-session-1:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
-					"old-session-2:agent_xyz": { edited: ["src/bar.ts"], lastSurfacedAt: null },
-				}),
+				JSON.stringify({ "dead-session": { "src/foo.ts": 1 } }),
 			);
 
-			clearStaleBuckets("abc123");
+			pruneDeadSessions(new Set());
 
-			expect(mockedUnlinkSync).toHaveBeenCalledWith(".claude/state/edited-files.json");
-			expect(mockedWriteFileSync).not.toHaveBeenCalled();
+			expect(mockedUnlinkSync).toHaveBeenCalledWith(".claude/state/lint-attempts.json");
 		});
 
-		it("should no-op when every bucket already belongs to current session", () => {
+		it("should no-op when every entry belongs to a live session", () => {
 			expect.assertions(2);
 
 			mockedUnlinkSync.mockClear();
 			mockedWriteFileSync.mockClear();
-			mockedExistsSync.mockReturnValue(true);
+			mockedExistsSync.mockImplementation(
+				(path) => path === ".claude/state/edited-files.json",
+			);
 			mockedReadFileSync.mockReturnValue(
 				JSON.stringify({
-					"abc123:agent_xyz": { edited: ["src/bar.ts"], lastSurfacedAt: null },
-					"abc123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
+					"live123:agent_xyz": { edited: ["src/bar.ts"], lastSurfacedAt: null },
+					"live123:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
 				}),
 			);
 
-			clearStaleBuckets("abc123");
+			pruneDeadSessions(new Set(["live123"]));
 
 			expect(mockedUnlinkSync).not.toHaveBeenCalled();
 			expect(mockedWriteFileSync).not.toHaveBeenCalled();
+		});
+
+		it("should unlink files with corrupt JSON", () => {
+			expect.assertions(1);
+
+			mockedUnlinkSync.mockClear();
+			mockedExistsSync.mockImplementation(
+				(path) => path === ".claude/state/lint-attempts.json",
+			);
+			mockedReadFileSync.mockReturnValue("{bad");
+
+			pruneDeadSessions(new Set(["live123"]));
+
+			expect(mockedUnlinkSync).toHaveBeenCalledWith(".claude/state/lint-attempts.json");
 		});
 
 		it("should not match a session id that is a prefix of a longer one", () => {
 			expect.assertions(1);
 
 			mockedWriteFileSync.mockClear();
-			mockedExistsSync.mockReturnValue(true);
+			mockedExistsSync.mockImplementation(
+				(path) => path === ".claude/state/edited-files.json",
+			);
 			mockedReadFileSync.mockReturnValue(
 				JSON.stringify({
 					"abc123:main": { edited: ["src/bar.ts"], lastSurfacedAt: null },
@@ -2512,7 +2771,7 @@ describe(lint, () => {
 				}),
 			);
 
-			clearStaleBuckets("abc");
+			pruneDeadSessions(new Set(["abc"]));
 
 			expect(mockedWriteFileSync).toHaveBeenCalledWith(
 				".claude/state/edited-files.json",
@@ -2520,18 +2779,6 @@ describe(lint, () => {
 					"abc:main": { edited: ["src/foo.ts"], lastSurfacedAt: null },
 				}),
 			);
-		});
-
-		it("should delete file on corrupt JSON", () => {
-			expect.assertions(1);
-
-			mockedUnlinkSync.mockClear();
-			mockedExistsSync.mockReturnValue(true);
-			mockedReadFileSync.mockReturnValue("{bad");
-
-			clearStaleBuckets("abc123");
-
-			expect(mockedUnlinkSync).toHaveBeenCalledWith(".claude/state/edited-files.json");
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Opening a new chat used to wipe the running chat's lint counters, edited-files bucket, and stop-attempts because `SessionStart` cleared state unconditionally. State is now keyed per session: `lint-attempts` by `session_id`, stop/typecheck-stop-attempts by `session_id:agent_id` bucket.
- `SessionStart` registers the claude PID under `.claude/state/sessions/` and prunes only entries whose owning session has a dead PID — replaces `clearAllBuckets`/`clearStaleBuckets`/`clearLintAttempts`/`clearStopAttempts`/`clearTypecheckStopAttempts` with a single `pruneDeadSessions` sweep.
- Hook PostToolUse paths use new `incrementLintAttempt` / `clearLintAttempt` helpers so the read-modify-write idiom stays in `scripts/lint.ts`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 234/234 pass (rewrote read/write tests for new shape; added 21 new tests for `incrementLintAttempt`, `clearLintAttempt`, `registerSession`, `loadLiveSessions`, `pruneDeadSessions`)
- [x] `pnpm lint` clean
- [x] e2e: pre-populated state for "chat A" with live PID, ran `clear-lint-state.ts` simulating "chat B" startup → chat A's lint/stop/typecheck/edited-files all survived; with a dead PID, all of A's entries were GC'd cleanly; `resume` on the same session preserved its state (12/12 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)