### PR TITLE
fix(lint): wait on cmd.exe only, not detached eslint_d daemon

### DIFF
--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -992,9 +992,14 @@ function runEslintWindowsChunk(
 	const errFile = join(tmpdir(), `eslint_d_err_${id}.txt`);
 
 	const inner = `${runner} eslint_d ${flags} ${quoteFiles(filePaths)} > "${outFile}" 2> "${errFile}"`;
+	// Use -PassThru + WaitForExit() instead of -Wait. PowerShell's -Wait waits
+	// for the started process AND all its descendants; eslint_d's forked daemon
+	// is a descendant of cmd.exe, so -Wait would block until the daemon dies
+	// (never). WaitForExit() calls WaitForSingleObject on just cmd.exe — the
+	// detached daemon is ignored, matching pre-shell-exec execSync semantics.
 	const psCmd =
 		`$p = Start-Process -FilePath 'cmd.exe' -ArgumentList @('/c', ${psSingleQuote(inner)}) ` +
-		"-WindowStyle Hidden -Wait -PassThru; exit $p.ExitCode";
+		"-WindowStyle Hidden -PassThru; $p.WaitForExit(); exit $p.ExitCode";
 
 	let exitCode = 0;
 	let launcherStderr = "";

--- a/test/lint.spec.ts
+++ b/test/lint.spec.ts
@@ -621,6 +621,29 @@ describe(lint, () => {
 			Object.defineProperty(process, "platform", { value: originalPlatform });
 		});
 
+		// PowerShell's Start-Process -Wait waits for the process AND all
+		// descendants. eslint_d's forked daemon is a descendant of cmd.exe, so
+		// -Wait blocks until the daemon exits (never). Must use -PassThru +
+		// WaitForExit() so we wait only on cmd.exe.
+		it("should wait via PassThru + WaitForExit, not -Wait", () => {
+			expect.assertions(2);
+
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, "platform", { value: "win32" });
+			mockedExecFileSync.mockReset();
+			mockedReadFileSync.mockReset();
+			mockedExecFileSync.mockReturnValue(Buffer.from(""));
+
+			runEslint([testFilePath]);
+
+			const psCommand = (findStartProcessCall()![1] as Array<string>)[2]!;
+
+			expect(psCommand).not.toMatch(/\s-Wait(\s|$)/);
+			expect(psCommand).toMatch(/-PassThru;\s*\$p\.WaitForExit\(\)/);
+
+			Object.defineProperty(process, "platform", { value: originalPlatform });
+		});
+
 		it("should return stdout content when eslint_d exits non-zero", () => {
 			expect.assertions(1);
 


### PR DESCRIPTION
## Summary

`Start-Process -Wait` waits for the launched process **and all its descendants**. `eslint_d`'s forked daemon is a descendant of the `cmd.exe` we launch via `Start-Process`, so `-Wait` would block until the daemon exits — i.e. forever.

Switch to `-PassThru` + `$p.WaitForExit()`, which calls `WaitForSingleObject` on `cmd.exe` only and ignores detached descendants. This restores pre-shell-exec `execSync` semantics.

- `scripts/lint.ts`: replace `-Wait` with `-PassThru; $p.WaitForExit()` in `runEslintWindowsChunk`
- `test/lint.spec.ts`: regression test asserting the PowerShell command does not contain `-Wait` and does contain `-PassThru; $p.WaitForExit()`

## Test Plan

- [x] New regression test passes
- [x] Existing lint test suite passes
- [ ] Manual: run lint hook on win32 and confirm it no longer hangs