### PR TITLE
feat: add lint-guard-allow carve-out to lint guard

### DIFF
--- a/hooks/CONFIGURATION.md
+++ b/hooks/CONFIGURATION.md
@@ -31,6 +31,7 @@ ignored.
 | `lintAutoFixOnBatch` | `lint-auto-fix-on-batch` | `boolean`                             | `true`        | Only used when `lintCadence` is `tiered` or `stop-only`. When `true`, the `PostToolBatch` hook runs `eslint --fix` on every file edited in the batch but does not surface results. Disable to skip the silent batch-fix pass. |
 | `cacheBust`          | `cache-bust`             | comma-separated globs                 | `*.config.*, **/tsconfig*.json` | Globs that force a full ESLint cache wipe when their mtime is newer than the cache. User patterns are appended to the defaults; prefix with `!` to exclude. |
 | `typecheckArgs`      | `typecheck-args`         | comma-separated strings               | `[]`          | Extra arguments passed to `tsgo`. When set, replaces the default `-p <tsconfig> --noEmit --pretty false` invocation with `tsgo <args> <tsconfig>`. |
+| `lintGuardAllow`     | `lint-guard-allow`       | comma-separated globs                 | `[]`          | Project-relative globs exempted from the lint guard. See [Lint guard](#lint-guard). |
 
 ### Notes on parsing
 
@@ -40,14 +41,40 @@ ignored.
   `false` disables them.
 - `oxlint` and `debug` default to disabled — only the literal string `true`
   enables them.
-- `cache-bust` and `typecheck-args` are comma-separated; whitespace around each
-  entry is trimmed and empty entries are dropped.
+- `cache-bust`, `typecheck-args`, and `lint-guard-allow` are comma-separated;
+  whitespace around each entry is trimmed and empty entries are dropped.
+- `lint-guard-allow` patterns are project-relative and `/`-separated, resolved
+  against `CLAUDE_PROJECT_DIR` (falling back to the working directory).
+  Comparison is case-insensitive on Windows.
 - `lint-cadence` falls back to `strict` if the value is not one of the three
   recognized strings.
 - `max-lint-attempts` and `max-lint-errors` accept any number; non-numeric
   values fall back to the default (only `max-lint-errors` is guarded against
   `NaN` — invalid `max-lint-attempts` values resolve to `NaN`, which makes the
   per-file loop guard never trip).
+
+## Lint guard
+
+A `PreToolUse` hook blocks `Edit` and `Write` on files whose name matches
+`eslint.config.*`, `oxlint.config.*`, `.eslintrc*`, `.oxlintrc.*`, or
+`sentinel.local.md`. The agent is told to report the offending rule instead of
+editing the config. The settings file is protected too, so an agent cannot
+grant itself a carve-out.
+
+`lint-guard-allow` is the only escape hatch. Patterns are globs matched against
+the file's project-relative path, so a monorepo can open one config while the
+rest stay protected:
+
+```yaml
+---
+lint-guard-allow: packages/app/eslint.config.ts
+---
+```
+
+With that setting, `packages/app/eslint.config.ts` is editable while
+`packages/lib/eslint.config.ts` and the root config remain blocked. Globs work
+too — `tools/**/eslint.config.*` exempts every config under `tools/`. Files
+outside the project directory are never exempt.
 
 ## Cadence modes
 

--- a/hooks/lint-guard.ts
+++ b/hooks/lint-guard.ts
@@ -2,7 +2,7 @@ import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 
 import { basename } from "node:path";
 
-import { isProtectedFile, narrowToolInput } from "../scripts/lint.ts";
+import { isGuardAllowed, isProtectedFile, narrowToolInput, readSettings } from "../scripts/lint.ts";
 import { readStdinJson, writeStdoutJson } from "./io.ts";
 
 const input = await readStdinJson<PreToolUseHookInput>();
@@ -10,7 +10,7 @@ const input = await readStdinJson<PreToolUseHookInput>();
 if (input.tool_name === "Write" || input.tool_name === "Edit") {
 	const filePath = narrowToolInput(input).file_path;
 	const fileName = basename(filePath);
-	if (isProtectedFile(fileName)) {
+	if (isProtectedFile(fileName) && !isGuardAllowed(filePath, readSettings().lintGuardAllow)) {
 		writeStdoutJson({
 			decision: "block",
 			reason: "Modifying linter config is forbidden. Report to user if a rule blocks your task.",

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -24,7 +24,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, relative, resolve, sep } from "node:path";
+import { dirname, join, matchesGlob, relative, resolve, sep } from "node:path";
 import process from "node:process";
 
 export type LintCadence = "stop-only" | "strict" | "tiered";
@@ -38,6 +38,7 @@ export interface LintSettings {
 	lint: boolean;
 	lintAutoFixOnBatch: boolean;
 	lintCadence: LintCadence;
+	lintGuardAllow: Array<string>;
 	maxLintAttempts: number;
 	maxLintErrors: number;
 	oxlint: boolean;
@@ -85,12 +86,55 @@ function spawnBackground(script: string, extraEnvironment: Record<string, string
 	}
 }
 
-const PROTECTED_PATTERNS = ["eslint.config.", "oxlint.config.", ".eslintrc", ".oxlintrc."];
+const PROTECTED_PATTERNS = [
+	"eslint.config.",
+	"oxlint.config.",
+	".eslintrc",
+	".oxlintrc.",
+	"sentinel.local.md",
+];
 
 export function isProtectedFile(filename: string): boolean {
 	return PROTECTED_PATTERNS.some(
 		(pattern) => filename.startsWith(pattern) || filename === pattern,
 	);
+}
+
+/**
+ * Checks whether a protected file is exempted by the `lint-guard-allow`
+ * setting. Patterns are globs matched against the file's project-relative,
+ * `/`-separated path, so a monorepo can exempt one package's config while the
+ * other configs stay protected.
+ *
+ * @param filePath - Path of the file being edited, absolute or relative.
+ * @param patterns - Allowlist globs from `LintSettings.lintGuardAllow`.
+ * @returns True when the file is exempt from the lint guard.
+ */
+export function isGuardAllowed(filePath: string, patterns: Array<string>): boolean {
+	if (patterns.length === 0) {
+		return false;
+	}
+
+	const relativePath = toProjectRelative(filePath);
+	if (relativePath.startsWith("../")) {
+		return false;
+	}
+
+	const target = normalizeCase(relativePath);
+	return patterns.some((pattern) => matchesGlob(target, normalizeCase(pattern)));
+}
+
+function normalizeCase(value: string): string {
+	return process.platform === "win32" ? value.toLowerCase() : value;
+}
+
+function toProjectRelative(filePath: string): string {
+	const projectDirectory = process.env["CLAUDE_PROJECT_DIR"];
+	const root =
+		projectDirectory === undefined || projectDirectory === ""
+			? process.cwd()
+			: projectDirectory;
+	return relative(resolve(root), resolve(filePath)).split(sep).join("/");
 }
 
 const LINT_STATE_PATH = ".claude/state/lint-attempts.json";
@@ -472,6 +516,7 @@ const DEFAULT_SETTINGS = {
 	lint: true,
 	lintAutoFixOnBatch: true,
 	lintCadence: DEFAULT_LINT_CADENCE,
+	lintGuardAllow: [],
 	maxLintAttempts: DEFAULT_MAX_LINT_ATTEMPTS,
 	maxLintErrors: DEFAULT_MAX_LINT_ERRORS,
 	oxlint: false,
@@ -510,14 +555,6 @@ export function readSettings(): LintSettings {
 	const content = readFileSync(SETTINGS_FILE, "utf-8");
 	const fields = parseFrontmatter(content);
 
-	const cacheBustRaw = fields.get("cache-bust") ?? "";
-	const userPatterns = cacheBustRaw
-		? cacheBustRaw
-				.split(",")
-				.map((entry) => entry.trim())
-				.filter(Boolean)
-		: [];
-
 	const maxAttemptsRaw = fields.get("max-lint-attempts");
 	const maxAttemptsParsed = maxAttemptsRaw !== undefined ? Number(maxAttemptsRaw) : Number.NaN;
 	const maxLintAttempts = Number.isFinite(maxAttemptsParsed)
@@ -538,21 +575,19 @@ export function readSettings(): LintSettings {
 			: DEFAULT_LINT_CADENCE;
 
 	return {
-		cacheBust: [...DEFAULT_CACHE_BUST, ...userPatterns],
+		cacheBust: [...DEFAULT_CACHE_BUST, ...parseList(fields.get("cache-bust"))],
 		debug: fields.get("debug") === "true",
 		eslint: fields.get("eslint") !== "false",
 		lint: fields.get("lint") !== "false",
 		lintAutoFixOnBatch: parseAutoFixOnBatch(fields.get("lint-auto-fix-on-batch")),
 		lintCadence,
+		lintGuardAllow: parseList(fields.get("lint-guard-allow")),
 		maxLintAttempts,
 		maxLintErrors,
 		oxlint: fields.get("oxlint") === "true",
 		runner: fields.get("runner") ?? DEFAULT_SETTINGS.runner,
 		typecheck: fields.get("typecheck") !== "false",
-		typecheckArgs: (fields.get("typecheck-args") ?? "")
-			.split(",")
-			.map((entry) => entry.trim())
-			.filter(Boolean),
+		typecheckArgs: parseList(fields.get("typecheck-args")),
 	};
 }
 
@@ -625,6 +660,7 @@ export function invertGraph(graph: DependencyGraph, target: string): Array<strin
 
 	return importers;
 }
+
 export function findSourceRoot(filePath: string): string | undefined {
 	let current = dirname(filePath);
 	while (current !== dirname(current)) {
@@ -642,7 +678,6 @@ export function findSourceRoot(filePath: string): string | undefined {
 
 	return undefined;
 }
-
 export function readLintAttempts(sessionId: string): Record<string, number> {
 	const state = readLintAttemptsState();
 	return state[sessionId] ?? {};
@@ -779,6 +814,13 @@ export function invalidateCacheEntries(filePaths: Array<string>): void {
 	}
 
 	cache.reconcile();
+}
+
+function parseList(raw: string | undefined): Array<string> {
+	return (raw ?? "")
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter(Boolean);
 }
 
 const MAX_COMMAND_LENGTH = 32_000;

--- a/test/lint-guard.spec.ts
+++ b/test/lint-guard.spec.ts
@@ -1,13 +1,31 @@
 import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import process from "node:process";
 import { describe, expect, it } from "vitest";
 
-function runGuard(filePath: string): string {
+const HOOK_PATH = resolve("hooks/lint-guard.ts");
+
+function runGuard(filePath: string, projectDirectory?: string): string {
 	const input = JSON.stringify({ tool_input: { file_path: filePath }, tool_name: "Edit" });
-	const result = spawnSync("node", ["hooks/lint-guard.ts"], {
+	const result = spawnSync("node", [HOOK_PATH], {
+		cwd: projectDirectory,
 		encoding: "utf-8",
+		env: { ...process.env, CLAUDE_PROJECT_DIR: projectDirectory ?? "" },
 		input,
 	});
 	return result.stdout.trim();
+}
+
+function makeProject(allow: string): string {
+	const root = mkdtempSync(join(tmpdir(), "lint-guard-"));
+	mkdirSync(join(root, ".claude"), { recursive: true });
+	writeFileSync(
+		join(root, ".claude", "sentinel.local.md"),
+		`---\nlint-guard-allow: ${allow}\n---\n`,
+	);
+	return root;
 }
 
 describe("lint-guard hook", () => {
@@ -44,5 +62,37 @@ describe("lint-guard hook", () => {
 		const output = runGuard("eslint-plugin/index.ts");
 
 		expect(output).toBe("");
+	});
+
+	it("should allow a config covered by lint-guard-allow", () => {
+		expect.assertions(1);
+
+		const root = makeProject("packages/app/eslint.config.ts");
+
+		const output = runGuard(join(root, "packages", "app", "eslint.config.ts"), root);
+
+		expect(output).toBe("");
+	});
+
+	it("should still block a config outside lint-guard-allow", () => {
+		expect.assertions(1);
+
+		const root = makeProject("packages/app/eslint.config.ts");
+
+		const output = runGuard(join(root, "packages", "lib", "eslint.config.ts"), root);
+		const parsed = JSON.parse(output) as { decision: string };
+
+		expect(parsed.decision).toBe("block");
+	});
+
+	it("should block edits to the sentinel settings file", () => {
+		expect.assertions(1);
+
+		const root = makeProject("packages/app/eslint.config.ts");
+
+		const output = runGuard(join(root, ".claude", "sentinel.local.md"), root);
+		const parsed = JSON.parse(output) as { decision: string };
+
+		expect(parsed.decision).toBe("block");
 	});
 });

--- a/test/lint.spec.ts
+++ b/test/lint.spec.ts
@@ -35,6 +35,7 @@ import {
 	incrementLintAttempt,
 	invalidateCacheEntries,
 	invertGraph,
+	isGuardAllowed,
 	isInProject,
 	isLintableFile,
 	isProtectedFile,
@@ -961,6 +962,7 @@ describe(lint, () => {
 				lint: true,
 				lintAutoFixOnBatch: true,
 				lintCadence: "strict",
+				lintGuardAllow: [],
 				maxLintAttempts: 1,
 				maxLintErrors: 10,
 				oxlint: false,
@@ -983,6 +985,7 @@ describe(lint, () => {
 				lint: true,
 				lintAutoFixOnBatch: true,
 				lintCadence: "strict",
+				lintGuardAllow: [],
 				maxLintAttempts: 1,
 				maxLintErrors: 10,
 				oxlint: false,
@@ -1016,6 +1019,7 @@ describe(lint, () => {
 				lint: true,
 				lintAutoFixOnBatch: true,
 				lintCadence: "strict",
+				lintGuardAllow: [],
 				maxLintAttempts: 1,
 				maxLintErrors: 10,
 				oxlint: true,
@@ -1362,6 +1366,7 @@ describe(lint, () => {
 				lint: true,
 				lintAutoFixOnBatch: true,
 				lintCadence: "strict",
+				lintGuardAllow: [],
 				maxLintAttempts: 1,
 				maxLintErrors: 10,
 				oxlint: true,
@@ -1403,6 +1408,7 @@ describe(lint, () => {
 				lint: true,
 				lintAutoFixOnBatch: true,
 				lintCadence: "strict",
+				lintGuardAllow: [],
 				maxLintAttempts: 1,
 				maxLintErrors: 10,
 				oxlint: true,
@@ -1671,6 +1677,7 @@ describe(lint, () => {
 				lint: true,
 				lintAutoFixOnBatch: true,
 				lintCadence: "strict",
+				lintGuardAllow: [],
 				maxLintAttempts: 1,
 				maxLintErrors: 10,
 				oxlint: true,
@@ -1726,6 +1733,7 @@ describe(lint, () => {
 				lint: true,
 				lintAutoFixOnBatch: true,
 				lintCadence: "strict",
+				lintGuardAllow: [],
 				maxLintAttempts: 1,
 				maxLintErrors: 10,
 				oxlint: true,
@@ -1763,6 +1771,7 @@ describe(lint, () => {
 				lint: true,
 				lintAutoFixOnBatch: true,
 				lintCadence: "strict",
+				lintGuardAllow: [],
 				maxLintAttempts: 1,
 				maxLintErrors: 10,
 				oxlint: false,
@@ -1798,6 +1807,30 @@ describe(lint, () => {
 			expect(readSettings()).toMatchObject({
 				cacheBust: [...DEFAULT_CACHE_BUST],
 			});
+		});
+	});
+
+	describe("readSettings lintGuardAllow", () => {
+		it("should parse a comma-separated pattern list", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue(
+				"---\nlint-guard-allow: packages/app/eslint.config.ts, tools/**/*.config.ts\n---\n",
+			);
+
+			expect(readSettings()).toMatchObject({
+				lintGuardAllow: ["packages/app/eslint.config.ts", "tools/**/*.config.ts"],
+			});
+		});
+
+		it("should default lintGuardAllow to an empty list", () => {
+			expect.assertions(1);
+
+			mockedExistsSync.mockReturnValue(true);
+			mockedReadFileSync.mockReturnValue("---\neslint: true\n---\n");
+
+			expect(readSettings()).toMatchObject({ lintGuardAllow: [] });
 		});
 	});
 
@@ -2066,6 +2099,7 @@ describe(lint, () => {
 				lint: true,
 				lintAutoFixOnBatch: true,
 				lintCadence: "strict",
+				lintGuardAllow: [],
 				maxLintAttempts: 1,
 				maxLintErrors: 10,
 				oxlint: false,
@@ -2095,6 +2129,7 @@ describe(lint, () => {
 				lint: true,
 				lintAutoFixOnBatch: true,
 				lintCadence: "strict",
+				lintGuardAllow: [],
 				maxLintAttempts: 1,
 				maxLintErrors: 10,
 				oxlint: false,
@@ -2549,6 +2584,109 @@ describe(lint, () => {
 			expect.assertions(1);
 
 			expect(isProtectedFile("eslint-plugin/index.ts")).toBe(false);
+		});
+
+		it("should block the sentinel settings file", () => {
+			expect.assertions(1);
+
+			expect(isProtectedFile("sentinel.local.md")).toBe(true);
+		});
+	});
+
+	describe(isGuardAllowed, () => {
+		it("should deny when no patterns are configured", () => {
+			expect.assertions(1);
+
+			vi.stubEnv("CLAUDE_PROJECT_DIR", "/project");
+
+			expect(isGuardAllowed(join("/project", "eslint.config.ts"), [])).toBe(false);
+
+			vi.unstubAllEnvs();
+		});
+
+		it("should allow an exact project-relative match", () => {
+			expect.assertions(1);
+
+			vi.stubEnv("CLAUDE_PROJECT_DIR", "/project");
+
+			const filePath = join("/project", "packages", "app", "eslint.config.ts");
+
+			expect(isGuardAllowed(filePath, ["packages/app/eslint.config.ts"])).toBe(true);
+
+			vi.unstubAllEnvs();
+		});
+
+		it("should allow a glob match", () => {
+			expect.assertions(1);
+
+			vi.stubEnv("CLAUDE_PROJECT_DIR", "/project");
+
+			const filePath = join("/project", "tools", "lint", "eslint.config.mjs");
+
+			expect(isGuardAllowed(filePath, ["tools/**/eslint.config.*"])).toBe(true);
+
+			vi.unstubAllEnvs();
+		});
+
+		it("should deny a sibling config that no pattern covers", () => {
+			expect.assertions(1);
+
+			vi.stubEnv("CLAUDE_PROJECT_DIR", "/project");
+
+			const filePath = join("/project", "packages", "lib", "eslint.config.ts");
+
+			expect(isGuardAllowed(filePath, ["packages/app/eslint.config.ts"])).toBe(false);
+
+			vi.unstubAllEnvs();
+		});
+
+		it("should deny a file outside the project", () => {
+			expect.assertions(1);
+
+			vi.stubEnv("CLAUDE_PROJECT_DIR", "/project");
+
+			expect(isGuardAllowed("/other/eslint.config.ts", ["**/eslint.config.*"])).toBe(false);
+
+			vi.unstubAllEnvs();
+		});
+
+		it("should resolve against cwd when CLAUDE_PROJECT_DIR is not set", () => {
+			expect.assertions(1);
+
+			vi.stubEnv("CLAUDE_PROJECT_DIR", "");
+
+			const filePath = join(process.cwd(), "packages", "app", "eslint.config.ts");
+
+			expect(isGuardAllowed(filePath, ["packages/app/eslint.config.ts"])).toBe(true);
+
+			vi.unstubAllEnvs();
+		});
+
+		it("should ignore case on windows", () => {
+			expect.assertions(1);
+
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, "platform", { value: "win32" });
+			vi.stubEnv("CLAUDE_PROJECT_DIR", "/project");
+
+			const filePath = join("/project", "Packages", "App", "eslint.config.ts");
+
+			expect(isGuardAllowed(filePath, ["packages/app/eslint.config.ts"])).toBe(true);
+
+			Object.defineProperty(process, "platform", { value: originalPlatform });
+			vi.unstubAllEnvs();
+		});
+
+		it("should respect case on non-windows", () => {
+			expect.assertions(1);
+
+			vi.stubEnv("CLAUDE_PROJECT_DIR", "/project");
+
+			const filePath = join("/project", "Packages", "App", "eslint.config.ts");
+
+			expect(isGuardAllowed(filePath, ["packages/app/eslint.config.ts"])).toBe(false);
+
+			vi.unstubAllEnvs();
 		});
 	});
 


### PR DESCRIPTION
## Why

The `PreToolUse` lint guard blocks `Edit`/`Write` on any file whose basename matches `eslint.config.*`, `oxlint.config.*`, `.eslintrc*`, or `.oxlintrc.*`. It read no settings, so there was no override. In a monorepo with several eslint configs, there was no way to open the one config an agent is allowed to touch.

## What

- `isGuardAllowed(filePath, patterns)` in `scripts/lint.ts` — globs matched against the project-relative, `/`-separated path, resolved from `CLAUDE_PROJECT_DIR` (falls back to cwd). Files outside the project are never exempt; matching ignores case on Windows.
- New `lint-guard-allow` setting (comma-separated globs) in `.claude/sentinel.local.md`, surfaced as `LintSettings.lintGuardAllow`.
- `sentinel.local.md` added to `PROTECTED_PATTERNS`, so an agent cannot write its own carve-out and retry.
- `hooks/lint-guard.ts` blocks only when the file is protected **and** not allowlisted. `readSettings()` runs only after `isProtectedFile` returns true, keeping the file read off the common edit path.
- The comma-split parsing shared by `cache-bust` and `typecheck-args` is now a `parseList` helper (third call site).
- `hooks/CONFIGURATION.md` gains a "Lint guard" section — the guard was previously undocumented — plus the settings-table row.

Usage:

```yaml
---
lint-guard-allow: packages/app/eslint.config.ts
---
```

`packages/app/eslint.config.ts` becomes editable; `packages/lib/eslint.config.ts` and the root config stay blocked.

## Reviewer notes

- Matching uses `matchesGlob` from `node:path` (stable on the `>=24.11` engine floor), so it is purely lexical — it works for `Write` on a file that does not exist yet.
- 268 tests pass (7 new: 8 unit cases for `isGuardAllowed`, 2 for the setting parse, 3 hook-level cases). `pnpm lint` and `pnpm typecheck` are clean.
- `pnpm test:coverage` still fails the 100% threshold on `scripts/lint.ts`, but that is pre-existing: baseline on `main` is 96.4% lines, this branch is 96.46%. The new code has no uncovered statements or branches.
- Verified end to end against a temp project: allowlisted config passes, sibling config blocked, settings file blocked, relative paths resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)