### PR TITLE
feat: declare typescript LSP with diagnostics disabled

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -12,5 +12,22 @@
 	"license": "MIT",
 	"keywords": ["tdd", "typescript", "collaboration", "best-practices", "workflows"],
 	"skills": "./no-op/",
-	"outputStyles": "./output-styles/"
+	"outputStyles": "./output-styles/",
+	"lspServers": {
+		"typescript": {
+			"command": "typescript-language-server",
+			"args": ["--stdio"],
+			"diagnostics": false,
+			"extensionToLanguage": {
+				".cjs": "javascript",
+				".cts": "typescript",
+				".js": "javascript",
+				".jsx": "javascriptreact",
+				".mjs": "javascript",
+				".mts": "typescript",
+				".ts": "typescript",
+				".tsx": "typescriptreact"
+			}
+		}
+	}
 }


### PR DESCRIPTION
Adds an `lspServers` entry to the `sentinel` plugin so the TypeScript language server runs with `"diagnostics": false` — navigation (go-to-definition, references, hover) stays available, but diagnostics are no longer pushed into Claude's context after edits.

Replaces `typescript-lsp@claude-plugins-official`, whose config is inline in Anthropic's marketplace.json and cannot be overridden locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)